### PR TITLE
Roms as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "centurion_isa"]
+	path = centurion_isa
+	url = https://github.com/phire/centurion_isa
+	branch = main

--- a/README.md
+++ b/README.md
@@ -34,13 +34,12 @@ There are differences however:
 
 ### Prerequisites
 
-* Download ROM bin files from https://github.com/phire/centurion_isa/tree/main/roms<br>
-    ```bootstrap_unscrambled.bin```<br>
-	```Diag_F1_Rev_1.0.BIN```<br>
-	```Diag_F2_Rev_1.0.BIN```<br>
-	```Diag_F3_Rev_1.0.BIN```<br>
-	```Diag_F4_1133CMD.BIN```
-* Install C compiler with Make
+* Install C compiler and Make
+* Clone this repository and submodules:
+```
+git clone --recursive https://github.com/EtchedPixels/Centurion.git
+```
+
 
 ### Compiling
 

--- a/centurion.c
+++ b/centurion.c
@@ -1059,12 +1059,12 @@ int main(int argc, char *argv[])
 		tty_init();
 	else
 		net_init(port);
-	load_rom("bootstrap_unscrambled.bin", 0x3FC00, 0x0200);
+	load_rom("centurion_isa/roms/bootstrap_unscrambled.bin", 0x3FC00, 0x0200);
 	if (diag) {
-		load_rom("Diag_F1_Rev_1.0.BIN", 0x08000, 0x0800);
-		load_rom("Diag_F2_Rev_1.0.BIN", 0x08800, 0x0800);
-		load_rom("Diag_F3_Rev_1.0.BIN", 0x09000, 0x0800);
-		load_rom("Diag_F4_1133CMD.BIN", 0x09800, 0x0800);
+		load_rom("centurion_isa/roms/Diag_F1_Rev_1.0.BIN", 0x08000, 0x0800);
+		load_rom("centurion_isa/roms/Diag_F2_Rev_1.0.BIN", 0x08800, 0x0800);
+		load_rom("centurion_isa/roms/Diag_F3_Rev_1.0.BIN", 0x09000, 0x0800);
+		load_rom("centurion_isa/roms/Diag_F4_1133CMD.BIN", 0x09800, 0x0800);
 	}
 
 	/* We don't worry here is this works or not */


### PR DESCRIPTION
This adds the `centurion_isa` repo as a submodule so users don't need to go and get them by themselves when cloning this repo.

Note that I hard-coded the roms path unix-style `/` and didn't put a #ifdef check for windows and its `\`-based paths. Not sure if that's fine (I rarely work in C).