### PR TITLE
Improvements for WIPL

### DIFF
--- a/centurion.c
+++ b/centurion.c
@@ -1120,7 +1120,6 @@ int main(int argc, char *argv[])
 			if (dma_read_cycle(cmd_dma_cmd_out()))
 				cmd_dma_cmd_out_done();
 		}
-		usleep(1);
 	}
 	return 0;
 }

--- a/cpu6.c
+++ b/cpu6.c
@@ -944,7 +944,6 @@ static int xor16(unsigned dsta, unsigned srcv)
 
 static int mov16(unsigned dsta, unsigned srcv)
 {
-	fprintf(stderr, "write16 %x %x\n", dsta, srcv);
 	mmu_mem_write16(dsta, srcv);
 	logic_flags16(srcv);
 	return 0;


### PR DESCRIPTION
Implemented some missing instructions, the WIPL now successfully boots up to NAME= prompt. Keyboard input doesn't work as interrupt isn't operational.