### PR TITLE
mux: Improve interrupt emulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,15 +112,16 @@ The following options can be used when running the emulator:
 
 The system trace outputs system IO to the terminal; useful for debugging. The `-t` option takes a value that is a [bitmask](https://en.wikipedia.org/wiki/Mask_(computing)) of the following:
 
-- `1`: Memory
-- `2`: Registers
-- `4`: CPU
-- `8`: FDC
-- `16`: CMD
+- `1`: Memory read
+- `2`: Memory write
+- `4`: Registers
+- `8`: CPU
+- `16`: FDC
+- `32`: CMD
 
-For example, in order to trace both *memory* and *registers*, set `-t 3`.
+For example, in order to trace both *memory* and *registers*, set `-t 7`.
 
 ## Halting the emulator
 
-To halt the emulator, simply press `Ctrl-\`, which will land you back on your terminal prompt.
+To halt the emulator, simply press `Ctrl-\` (on Unix) or `Ctrl-Z` (on Windows), which will land you back on your terminal prompt.
 

--- a/centurion.c
+++ b/centurion.c
@@ -711,7 +711,7 @@ static uint8_t io_read8(uint16_t addr)
 	if (addr >= 0xF140 && addr <= 0xF14F)
 		return hawk_read(addr);
 	if (addr >= 0xF200 && addr <= 0xF21F)
-		return mux_read(addr);
+		return mux_read(addr, trace & TRACE_MUX);
 	fprintf(stderr, "%04X: Unknown I/O read %04X\n", cpu6_pc(), addr);
 	return 0;
 }
@@ -731,7 +731,7 @@ static void io_write8(uint16_t addr, uint8_t val)
 		hawk_write(addr, val);
 		return;
 	} else if (addr >= 0xF200 && addr <= 0xF21F) {
-		mux_write(addr, val);
+		mux_write(addr, val, trace & TRACE_MUX);
 		return;
 	} else
 		fprintf(stderr, "%04X: Unknown I/O write %04X %02X\n",

--- a/cpu6.c
+++ b/cpu6.c
@@ -551,9 +551,9 @@ static int bignum_op() {
 		char buffer[32];
 
 		if (base == 10) {
-			snprintf(buffer, sizeof(buffer), "%lu", num);
+			snprintf(buffer, sizeof(buffer), "%llu", num);
 		} else if (base == 16) {
-			snprintf(buffer, sizeof(buffer), "%lX", num);
+			snprintf(buffer, sizeof(buffer), "%llX", num);
 		} else {
 			fprintf(stderr, "baseconv, unsupported base %i\n", base);
 			exit(1);

--- a/mux.c
+++ b/mux.c
@@ -83,10 +83,6 @@ static void mux_assert_irq(unsigned unit, unsigned direction)
 		return;
 	// Cause register specifies the mux unit ID that caused the interrupt
 	// If we had multiple MUX4 boards, the board ID would be in the upper nibble
-	// I've implemented this as just overwriting the last cause, which will cause issues
-	// Would be interesting to see if the hardware has some kind of queue
-	//
-	// Ken mentions that sometimes key presses would be dropped under heavy loads
 	irq_cause = (unit << 1) | direction;
 	cpu_assert_irq(ipl);
 }
@@ -131,6 +127,14 @@ void mux_write(uint16_t addr, uint8_t val)
 		fprintf(stderr, "\nMux, RX Configured to LVL %x\n", val);
 		rx_ipl_request = val;
 		return;
+	} else if (addr == 0xC) {
+		/* OPSYS kernel writes unit number (starting from 1)
+		 * to this register and waits for the interrupt-driven write
+		 * to complete. We suggest that this write forces a TX_READY interrupt
+		 * on the given unit. Before doing so, the output routine actually
+		 * waits for MUX_TX_READY bit to go high using a polled loop
+		 */
+		mux_assert_irq(val - 1, MUX_IRQ_TX);
 	} else if (addr == 0xE) {
 		fprintf(stderr, "\nMux, TX Configured to LVL %x\n", val);
 		tx_ipl_request = val;
@@ -216,7 +220,7 @@ uint8_t mux_read(uint16_t addr)
 		return next_char(unit);	/*( | 0x80; */
 	}
 
-	return mux[unit].status | check_write_ready(unit);
+	return mux[unit].status | check_write_ready(unit) | MUX_CTS;
 }
 
 static void set_read_ready(unsigned unit)
@@ -255,6 +259,7 @@ void mux_poll(void)
 			/* Do not waste time repetitively polling ports,
 			 * which we know are ready
 			 */
+			mux_assert_irq(unit, MUX_IRQ_RX);
 			continue;
 		}
 		int fd = mux[unit].in_fd;
@@ -280,8 +285,10 @@ void mux_poll(void)
 	for (unit = 0; unit < NUM_MUX_UNITS; unit++) {
 		if (mux[unit].status & MUX_RX_READY) {
 			/* Do not waste time repetitively polling ports,
-			 * which we know are ready
+			 * which we know are ready. But keep re-asserting the IRQ
+			 * if configured
 			 */
+			mux_assert_irq(unit, MUX_IRQ_RX);
 			continue;
 		}
 		int fd = mux[unit].in_fd;

--- a/mux.h
+++ b/mux.h
@@ -15,6 +15,7 @@ struct MuxUnit
 /* Status register bits */
 #define MUX_RX_READY (1 << 0)
 #define MUX_TX_READY (1 << 1)
+#define MUX_CTS      (1 << 5)
 
 /* Interrupt status register bits */
 #define MUX_IRQ_RX 0

--- a/mux.h
+++ b/mux.h
@@ -27,5 +27,5 @@ void tty_init(void);
 void net_init(unsigned short port);
 void mux_poll(void);
 
-void mux_write(uint16_t addr, uint8_t val);
-uint8_t mux_read(uint16_t addr);
+void mux_write(uint16_t addr, uint8_t val, uint32_t trace);
+uint8_t mux_read(uint16_t addr, uint32_t trace);


### PR DESCRIPTION
RX interrupt will be re-triggered if the IRQ handler didn't service input. This
is done for preventing IRQ losses because in @LOAD the same IPL 6 is used for
both rx and tx, but only one of these events is serviced per interrupt.

CTS is hardcoded to 1 in order to allow the output routine to run