### PR TITLE
Load can now read/write to the terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,15 +112,16 @@ The following options can be used when running the emulator:
 
 The system trace outputs system IO to the terminal; useful for debugging. The `-t` option takes a value that is a [bitmask](https://en.wikipedia.org/wiki/Mask_(computing)) of the following:
 
-- `1`: Memory
-- `2`: Registers
-- `4`: CPU
-- `8`: FDC
-- `16`: CMD
+- `1`: Memory read
+- `2`: Memory write
+- `4`: Registers
+- `8`: CPU
+- `16`: FDC
+- `32`: CMD
 
-For example, in order to trace both *memory* and *registers*, set `-t 3`.
+For example, in order to trace both *memory* and *registers*, set `-t 7`.
 
 ## Halting the emulator
 
-To halt the emulator, simply press `Ctrl-\`, which will land you back on your terminal prompt.
+To halt the emulator, simply press `Ctrl-\` (on Unix) or `Ctrl-Z` (on Windows), which will land you back on your terminal prompt.
 

--- a/centurion.c
+++ b/centurion.c
@@ -944,7 +944,7 @@ int main(int argc, char *argv[])
 				cmd_dma_cmd_out_done();
 		}
 		/* Update peripherals state */
-		mux_poll();
+		mux_poll(trace & TRACE_MUX);
 
 		instruction_count++;
 		if (terminate_at && instruction_count >= terminate_at) {

--- a/centurion.c
+++ b/centurion.c
@@ -711,7 +711,7 @@ static uint8_t io_read8(uint16_t addr)
 	if (addr >= 0xF140 && addr <= 0xF14F)
 		return hawk_read(addr);
 	if (addr >= 0xF200 && addr <= 0xF21F)
-		return mux_read(addr);
+		return mux_read(addr, trace & TRACE_MUX);
 	fprintf(stderr, "%04X: Unknown I/O read %04X\n", cpu6_pc(), addr);
 	return 0;
 }
@@ -731,7 +731,7 @@ static void io_write8(uint16_t addr, uint8_t val)
 		hawk_write(addr, val);
 		return;
 	} else if (addr >= 0xF200 && addr <= 0xF21F) {
-		mux_write(addr, val);
+		mux_write(addr, val, trace & TRACE_MUX);
 		return;
 	} else
 		fprintf(stderr, "%04X: Unknown I/O write %04X %02X\n",

--- a/cpu6.c
+++ b/cpu6.c
@@ -551,9 +551,9 @@ static int bignum_op() {
 		char buffer[32];
 
 		if (base == 10) {
-			snprintf(buffer, sizeof(buffer), "%lu", num);
+			snprintf(buffer, sizeof(buffer), "%llu", num);
 		} else if (base == 16) {
-			snprintf(buffer, sizeof(buffer), "%lX", num);
+			snprintf(buffer, sizeof(buffer), "%llX", num);
 		} else {
 			fprintf(stderr, "baseconv, unsupported base %i\n", base);
 			exit(1);

--- a/cpu6.c
+++ b/cpu6.c
@@ -32,7 +32,7 @@ static uint8_t alu_out;
 static uint8_t switches = 0xF0;
 static uint8_t int_enable;
 static unsigned halted;
-static unsigned pending_ipl;
+static unsigned pending_ipl = 0;
 
 #define BS1	0x01
 #define BS2	0x02
@@ -2048,19 +2048,17 @@ void cpu6_interrupt(unsigned trace)
 	}
 }
 
-/*
- * This is an utter crappy hack; in real life multiple IRQs
- * may be asserted at the same time, so we need to choose an
- * appropriate pending IPL and manage our state accordingly,
- * but this will do for now, when we only have one MUX generating
- * a single IRQ.
- */
-void cpu_assert_irq(unsigned ipl) {
+// Not quite accurate to real hardware, but hopefully close enough
+int cpu_assert_irq(unsigned ipl) {
+	if (pending_ipl == ipl || pending_ipl > ipl)
+		return 0;
 	pending_ipl = ipl;
+	return 1;
 }
 
 void cpu_deassert_irq(unsigned ipl) {
-	pending_ipl = 0;
+	if (pending_ipl == ipl)
+		pending_ipl = 0;
 }
 
 unsigned cpu6_execute_one(unsigned trace)

--- a/cpu6.c
+++ b/cpu6.c
@@ -1671,8 +1671,10 @@ static int cpu6_indexed_loadstore(void)
 		break;
 	case 0x10: // 8 bit load
 		reg_write(reg, mmu_mem_read8(addr));
+		break;
 	case 0x11: // 8 bit store
 		mmu_mem_write8(addr, reg_read(reg));
+		break;
 	}
 
 	ldflags(reg);

--- a/cpu6.h
+++ b/cpu6.h
@@ -40,7 +40,7 @@ extern int dma_write_active(void);
 extern void cpu6_set_switches(unsigned switches);
 extern unsigned cpu6_halted(void);
 extern void cpu6_init(void);
-extern void cpu_assert_irq(unsigned ipl);
+extern int cpu_assert_irq(unsigned ipl);
 extern void cpu_deassert_irq(unsigned ipl);
 extern void advance_time(uint64_t nanoseconds);
 extern uint64_t get_current_time();

--- a/mux.c
+++ b/mux.c
@@ -83,10 +83,6 @@ static void mux_assert_irq(unsigned unit, unsigned direction)
 		return;
 	// Cause register specifies the mux unit ID that caused the interrupt
 	// If we had multiple MUX4 boards, the board ID would be in the upper nibble
-	// I've implemented this as just overwriting the last cause, which will cause issues
-	// Would be interesting to see if the hardware has some kind of queue
-	//
-	// Ken mentions that sometimes key presses would be dropped under heavy loads
 	irq_cause = (unit << 1) | direction;
 	cpu_assert_irq(ipl);
 }
@@ -131,6 +127,14 @@ void mux_write(uint16_t addr, uint8_t val)
 		fprintf(stderr, "\nMux, RX Configured to LVL %x\n", val);
 		rx_ipl_request = val;
 		return;
+	} else if (addr == 0xC) {
+		/* OPSYS kernel writes unit number (starting from 1)
+		 * to this register and waits for the interrupt-driven write
+		 * to complete. We suggest that this write forces a TX_READY interrupt
+		 * on the given unit. Before doing so, the output routine actually
+		 * waits for MUX_TX_READY bit to go high using a polled loop
+		 */
+		mux_assert_irq(val - 1, MUX_IRQ_TX);
 	} else if (addr == 0xE) {
 		fprintf(stderr, "\nMux, TX Configured to LVL %x\n", val);
 		tx_ipl_request = val;
@@ -216,7 +220,7 @@ uint8_t mux_read(uint16_t addr)
 		return next_char(unit);	/*( | 0x80; */
 	}
 
-	return mux[unit].status | check_write_ready(unit);
+	return mux[unit].status | check_write_ready(unit) | MUX_CTS;
 }
 
 static void set_read_ready(unsigned unit)
@@ -255,6 +259,7 @@ void mux_poll(void)
 			/* Do not waste time repetitively polling ports,
 			 * which we know are ready
 			 */
+			mux_assert_irq(unit, MUX_IRQ_RX);
 			continue;
 		}
 		int fd = mux[unit].in_fd;
@@ -280,8 +285,10 @@ void mux_poll(void)
 	for (unit = 0; unit < NUM_MUX_UNITS; unit++) {
 		if (mux[unit].status & MUX_RX_READY) {
 			/* Do not waste time repetitively polling ports,
-			 * which we know are ready
+			 * which we know are ready. But keep re-asserting the IRQ
+			 * if configured
 			 */
+			mux_assert_irq(unit, MUX_IRQ_RX);
 			continue;
 		}
 		int fd = mux[unit].in_fd;

--- a/mux.c
+++ b/mux.c
@@ -13,7 +13,8 @@ static struct MuxUnit mux[NUM_MUX_UNITS];
  // LOAD writes 0 to F20A before transferring execution to a new binary
 static char rx_ipl_request = 0;
 static char tx_ipl_request = 0;
-static int irq_cause = 0;
+static int irq_cause_unit = -1;
+static int irq_cause_reason = -1;
 
 // Set the initial state for all out ports
 void mux_init(void)
@@ -25,6 +26,9 @@ void mux_init(void)
 		mux[i].out_fd = -1;
 		mux[i].status = 0;
 		mux[i].lastc = 0xFF;
+		mux[i].baud = 9600;
+		mux[i].tx_finish_time = 0;
+		mux[i].rx_finish_time = 0;
 	}
 }
 
@@ -48,6 +52,7 @@ static unsigned int next_char(uint8_t unit)
 	int r;
 	unsigned char c;
 
+
 	if (mux[unit].in_fd == -1) {
 		return mux[unit].lastc;
 	}
@@ -61,9 +66,9 @@ static unsigned int next_char(uint8_t unit)
 
 	if (r < 0) {
 		/* Someone read the port when nothing there */
-		if (errno == EAGAIN || errno == EWOULDBLOCK)
+		if (errno == EAGAIN || errno == EWOULDBLOCK) {
 			return mux[unit].lastc;
-		perror("next_char");
+		}
 		exit(1);
 	}
 
@@ -72,19 +77,78 @@ static unsigned int next_char(uint8_t unit)
 		c = 0x08;
 	}
 
+
 	mux[unit].lastc = c;
+
 	return c;
 }
 
-static void mux_assert_irq(unsigned unit, unsigned direction)
+static void mux_assert_irq(unsigned unit, unsigned reason, unsigned trace)
 {
-	char ipl = direction ? tx_ipl_request : rx_ipl_request;
+	char ipl = reason ? tx_ipl_request : rx_ipl_request;
 	if (!ipl)
 		return;
-	// Cause register specifies the mux unit ID that caused the interrupt
-	// If we had multiple MUX4 boards, the board ID would be in the upper nibble
-	irq_cause = (unit << 1) | direction;
-	cpu_assert_irq(ipl);
+
+	if (irq_cause_reason != -1)
+		return; // Already pending interrupt
+
+	int raised = cpu_assert_irq(ipl);
+	if (raised) {
+		irq_cause_unit = unit;
+		irq_cause_reason = reason;
+
+		if (trace && reason == MUX_IRQ_RX)
+				fprintf(stderr, "MUX%i: RX IRQ raised\n", unit);
+
+		if (trace && reason == MUX_IRQ_TX)
+				fprintf(stderr, "MUX%i: TX IRQ raised\n", unit);
+	}
+
+}
+
+static void mux_ack_irq(unsigned unit, unsigned reason, unsigned trace) {
+	char ipl = reason ? tx_ipl_request : rx_ipl_request;
+	if (!ipl)
+		return;
+
+	if (irq_cause_reason == reason && irq_cause_unit == unit) {
+		irq_cause_unit = -1;
+		irq_cause_reason = -1;
+		cpu_deassert_irq(ipl);
+
+		if (trace && reason == MUX_IRQ_RX)
+			fprintf(stderr, "MUX%i: RX IRQ acknowledged\n", unit);
+
+		if (trace && reason == MUX_IRQ_TX)
+			fprintf(stderr, "MUX%i: TX IRQ acknowledged\n", unit);
+	}
+}
+
+static void mux_unit_send(unsigned unit, uint8_t val) {
+	uint64_t symbol_len = 1000000000.0 / (float)mux[unit].baud;
+
+	mux[unit].status &= ~MUX_TX_READY;
+	mux[unit].tx_finish_time = get_current_time() + symbol_len * 10;
+
+	if (mux[unit].out_fd == -1) {
+		/* This MUX unit isn't connected to anything */
+		return;
+	}
+
+	if (mux[unit].out_fd > 1) {
+		val &= 0x7F;
+		write(mux[unit].out_fd, &val, 1);
+	} else {
+		val &= 0x7F;
+		if (val == 0x06) /* Cursor one position right */
+			printf("\x1b[1C");
+		else if (val != 0x08 && val != 0x0A && val != 0x0D
+		    && (val < 0x20 || val == 0x7F))
+			printf("[%02X]", val);
+		else
+			putchar(val);
+		fflush(stdout);
+	}
 }
 
 /*
@@ -119,140 +183,180 @@ static void mux_assert_irq(unsigned unit, unsigned direction)
    we ignore that */
 void mux_write(uint16_t addr, uint8_t val, uint32_t trace)
 {
-	unsigned unit, data;
-	addr &= 0xFF;
+	unsigned card, unit, port, mode;
 
-	if (addr == 0x0A) {
-		// Register 0x0A - set interrupt request level
+	// Decode address
+
+	// Nibble 1 of the address is the card number
+	// Each MUX4 board supports 4 ports.
+	// There are apparently MUX8 cards, which might act as two cards?
+	card = (addr >> 4) & 0xF;
+
+	mode = addr & 0xf;
+	if (mode > 8) {
+		port = 0;
+		unit = card * 4;
+	} else {
+		// Data or status
+		mode &= 1;
+		// Bits 1 and 2 are port
+		port = (addr >> 1) & 0x3;
+		unit = card * 4 + port;
+	}
+
+	if (unit > NUM_MUX_UNITS) {
+		fprintf(stderr, "MUX%i: Write to disabled unit reg %x\n", unit, addr);
+		return;
+	}
+
+	switch(mode) {
+	case 0: // Status Reg
 		if (trace)
-			fprintf(stderr, "\nMux, RX Configured to LVL %x\n", val);
+			fprintf(stderr, "MUX%i: Status Write %x\n", unit, val);
+		// TODO: Implement baud
+		return;
+	case 1: // Data Reg
+		if (trace) {
+			if ((val&0x7f) >= 0x20 && val != 0x7F && val != 0xff)
+				fprintf(stderr, "MUX%i: Data Write %x ('%c')\n", unit, val, val & 0x7f);
+			else
+				fprintf(stderr, "MUX%i: Data Write %x\n", unit, val);
+		}
+		mux_unit_send(unit, val);
+		return;
+	case 0xA: // Set RX interrupt request level
+		if (trace)
+			fprintf(stderr, "MUX%i: RX level = %i\n", unit, val);
 		rx_ipl_request = val;
 		return;
-	} else if (addr == 0xC) {
+	case 0xC:
 		/* OPSYS kernel writes unit number (starting from 1)
 		 * to this register and waits for the interrupt-driven write
 		 * to complete. We suggest that this write forces a TX_READY interrupt
 		 * on the given unit. Before doing so, the output routine actually
 		 * waits for MUX_TX_READY bit to go high using a polled loop
 		 */
-		mux_assert_irq(val - 1, MUX_IRQ_TX);
-	} else if (addr == 0xE) {
+		mux_assert_irq(val - 1, MUX_IRQ_TX, trace);
+		return;
+	case 0xE: // Set TX interrupt request level
 		if (trace)
-			fprintf(stderr, "\nMux, TX Configured to LVL %x\n", val);
+			fprintf(stderr, "MUX%i: TX level = %i\n", unit, val);
 		tx_ipl_request = val;
 		return;
-	} else if (addr >= NUM_MUX_UNITS * 2) {
-		if (trace)
-			fprintf(stderr, "\n%04X Write to unknown MUX register %x=%02x\n", cpu6_pc(), addr, val);
-		// Any other out-of-band address, we don't know what to do with it
+	case 0xF:
+		// acknowledges the interrupt
+		mux_ack_irq(unit, val, trace);
 		return;
-	}
-
-	unit = (addr >> 1) & 0x0F;
-	data = addr & 1;
-
-	if (!data) {
-		/* This is mode byte, we currently don't have anything
-		 * to do with it.
-		 * But if we wanted to operate on a real serial port, we'd need
-		 * to change baud rate here.
-		 * The code we have (diag test #6 and WIPL) loves to reset it every time.
-		 * I have also never seen clearing register 0x0A; so i assume it also
-		 * disables interrupt generation until requested explicitly.
-		 */
-		if (rx_ipl_request != 0) {
-			cpu_deassert_irq(rx_ipl_request);
-			rx_ipl_request = 0;
-		}
+	case 0xB:
+		// Written by CRT driver
+		if (!trace)
+			return; // Hide when not tracing
+	default:
+		fprintf(stderr, "\n%04X Write to unknown MUX register %x=%02x\n", cpu6_pc(), addr, val);
 		return;
-	}
-
-	uint64_t symbol_len = 1000000000.0 / 9600.0; // Hardcoded to 9600 baud
-
-	mux[unit].status &= ~MUX_TX_READY;
-	mux[unit].tx_finish_time = get_current_time() + symbol_len * 10;
-
-	if (mux[unit].out_fd == -1) {
-		/* This MUX unit isn't connected to anything */
-		return;
-	}
-
-	if (mux[unit].out_fd > 1) {
-		val &= 0x7F;
-		write(mux[unit].out_fd, &val, 1);
-	} else {
-		val &= 0x7F;
-		if (val == 0x06) /* Cursor one position right */
-			printf("\x1b[1C");
-		else if (val != 0x08 && val != 0x0A && val != 0x0D
-		    && (val < 0x20 || val == 0x7F))
-			printf("[%02X]", val);
-		else
-			putchar(val);
-		fflush(stdout);
 	}
 }
 
 uint8_t mux_read(uint16_t addr, uint32_t trace)
 {
-	unsigned unit, data;
+	unsigned card, port, unit, data, mode;
 
-	addr &= 0xFF;
+	data = 0;
 
-	if (addr == 0x0F) {
-		/* Reading from 0x0F supposedly ACKs the interrupt */
-		if (rx_ipl_request != 0) {
-			cpu_deassert_irq(rx_ipl_request);
-		}
-		if (tx_ipl_request != 0) {
-			cpu_deassert_irq(tx_ipl_request);
-		}
-		return irq_cause;
-	} else if (addr >= NUM_MUX_UNITS * 2) {
+	// It seems that all mux units share the same cause register via chaining
+	if (addr == 0xf20f) {
+		card = irq_cause_unit / 4;
+		port = irq_cause_unit % 4;
+
+		// Cause is actually the lower 8 bits of unit that caused the interrupt
+		// Though, TX interrupts have the lower bit set
+		unsigned cause = (card << 4) | (port << 1) | irq_cause_reason;
+
 		if (trace)
-			fprintf(stderr, "Read from unknown MUX register %x\n", addr);
-		// Any other out-of-band address, we don't know what to do with it
-		return 0;
+			fprintf(stderr, "MUX: InterruptCause Read: %02x\n", cause | 8);
+
+		return cause;
 	}
 
-	unit = addr >> 1;
-	data = addr & 1;
+	// Decode address
 
-	if (data == 1) {
-		/* Reading the data register resets RX_READY */
+	// Nibble 1 of the address is the card number
+	// Each MUX4 board supports 4 ports.
+	// There are apparently MUX8 cards, which might act as two cards?
+	card = (addr >> 4) & 0xF;
+
+
+	mode = addr & 0xf;
+	if (mode > 8) {
+		unit = card*4;
+	} else {
+		// Bits 1 and 2 are port
+		port = (mode >> 1) & 0x3;
+		unit = card * 4 + port;
+		mode = mode & 1;
+	}
+
+	if (unit > NUM_MUX_UNITS) {
+		if (addr != 0xf20f)
+			fprintf(stderr, "MUX%i: Read to disabled unit reg %x", unit, addr);
+		return data;
+	}
+
+	switch (mode)
+	{
+	case 0x0: // Status register
+		// Force CTS on
+		data = mux[unit].status | check_write_ready(unit) | MUX_CTS;
+		if (trace)
+			fprintf(stderr, "MUX%i: Status Read = %02x\n", unit, data);
+
+		break;
+	case 0x1:
+		// Data register
+		data = next_char(port);
 		mux[unit].status &= ~MUX_RX_READY;
-		return next_char(unit);	/*( | 0x80; */
+		mux_ack_irq(unit, MUX_IRQ_RX, trace);
+		if (trace)
+			fprintf(stderr, "MUX%i: Data Read = %02x ('%c')\n", unit, data, data);
+		break;
+	default:
+		fprintf(stderr, "MUX%i: Unknown Register %x Read\n", unit, addr);
+		break;
 	}
 
-	return mux[unit].status | check_write_ready(unit) | MUX_CTS;
+	return data;
 }
 
-static void set_read_ready(unsigned unit)
+static void set_read_ready(unsigned unit, unsigned trace)
 {
+	if ((mux[unit].status & MUX_RX_READY) == 0) {
+		if (trace)
+			fprintf(stderr, "MUX%i: Ready\n", unit);
+		mux[unit].rx_finish_time = get_current_time() + (1000000000 / 30);
+	}
 	mux[unit].status |= MUX_RX_READY;
-	mux_assert_irq(unit, MUX_IRQ_RX);
 }
 
-static void set_write_ready(unsigned unit)
+static void set_write_ready(unsigned unit, unsigned trace)
 {
 	mux[unit].status |= MUX_TX_READY;
 	mux[unit].tx_finish_time = 0;
-	mux_assert_irq(unit, MUX_IRQ_TX);
+	mux_assert_irq(unit, MUX_IRQ_TX, trace);
 }
 
-static void check_tx_done() {
+static void check_tx_done(unsigned trace) {
 	uint64_t time = get_current_time();
 	for (unsigned unit = 0; unit < NUM_MUX_UNITS; unit++) {
 		uint64_t finish = mux[unit].tx_finish_time;
 		if (finish && finish <= time) {
-			set_write_ready(unit);
+			set_write_ready(unit, trace);
 		}
 	}
 }
 
 #ifdef WIN32
 
-void mux_poll(void)
+void mux_poll(unsigned trace)
 {
 	int unit;
 
@@ -269,22 +373,24 @@ void mux_poll(void)
 		int fd = mux[unit].in_fd;
 
 	    	if (fd != -1 && tty_check_readable(fd)) {
-			set_read_ready(unit);
+			set_read_ready(unit, trace);
 		}
 	}
 }
 
 #else
 
-void mux_poll(void)
+void mux_poll(unsigned trace)
 {
 	fd_set i;
 	int max_fd = 0;
 	int unit;
 
-	check_tx_done();
+	check_tx_done(trace);
 
 	FD_ZERO(&i);
+
+	uint64_t time = get_current_time();
 
 	for (unit = 0; unit < NUM_MUX_UNITS; unit++) {
 		if (mux[unit].status & MUX_RX_READY) {
@@ -292,7 +398,11 @@ void mux_poll(void)
 			 * which we know are ready. But keep re-asserting the IRQ
 			 * if configured
 			 */
-			mux_assert_irq(unit, MUX_IRQ_RX);
+			mux_assert_irq(unit, MUX_IRQ_RX, trace);
+			continue;
+		}
+		if (mux[unit].rx_finish_time > time) {
+			// Block until the character has finished receiving
 			continue;
 		}
 		int fd = mux[unit].in_fd;
@@ -311,7 +421,7 @@ void mux_poll(void)
 		int fd = mux[unit].in_fd;
 
 		if (fd != -1 && FD_ISSET(fd, &i))
-			set_read_ready(unit);
+			set_read_ready(unit, trace);
 	}
 }
 

--- a/mux.h
+++ b/mux.h
@@ -15,6 +15,7 @@ struct MuxUnit
 /* Status register bits */
 #define MUX_RX_READY (1 << 0)
 #define MUX_TX_READY (1 << 1)
+#define MUX_CTS      (1 << 5)
 
 /* Interrupt status register bits */
 #define MUX_IRQ_RX 0

--- a/mux.h
+++ b/mux.h
@@ -27,5 +27,5 @@ void tty_init(void);
 void net_init(unsigned short port);
 void mux_poll(void);
 
-void mux_write(uint16_t addr, uint8_t val);
-uint8_t mux_read(uint16_t addr);
+void mux_write(uint16_t addr, uint8_t val, uint32_t trace);
+uint8_t mux_read(uint16_t addr, uint32_t trace);

--- a/mux.h
+++ b/mux.h
@@ -9,7 +9,9 @@ struct MuxUnit
         int out_fd;
         unsigned char status;
         unsigned char lastc;
+        int baud;
         uint64_t tx_finish_time;
+        uint64_t rx_finish_time;
 };
 
 /* Status register bits */
@@ -25,7 +27,7 @@ void mux_init(void);
 void mux_attach(unsigned unit, int in_fd, int out_fd);
 void tty_init(void);
 void net_init(unsigned short port);
-void mux_poll(void);
+void mux_poll(unsigned trace);
 
 void mux_write(uint16_t addr, uint8_t val, uint32_t trace);
 uint8_t mux_read(uint16_t addr, uint32_t trace);


### PR DESCRIPTION
Required large fixes to how mux does interrupts. And fixing the F6 instruction 

Current output:
```
% ./centurion
[0C]D=H0
[14][0C][1B][1C]LOS 7.1 - E

NAME=?.?TMOS
DISK=0
Unsupported 46 Bignum op 8
```