### PR TITLE
Rewrite interrupt handling

### DIFF
--- a/console.h
+++ b/console.h
@@ -1,9 +1,2 @@
 void tty_init(void);
 void net_init(unsigned short port);
-unsigned int tty_check_writable(int fd);
-
-#ifdef WIN32
-int tty_check_readable(int fd);
-#else
-int select_wrapper(int maxfd, fd_set* i, fd_set* o);
-#endif

--- a/cpu6.h
+++ b/cpu6.h
@@ -40,7 +40,7 @@ extern int dma_write_active(void);
 extern void cpu6_set_switches(unsigned switches);
 extern unsigned cpu6_halted(void);
 extern void cpu6_init(void);
-extern int cpu_assert_irq(unsigned ipl);
+extern void cpu_assert_irq(unsigned ipl);
 extern void cpu_deassert_irq(unsigned ipl);
 extern void advance_time(uint64_t nanoseconds);
 extern uint64_t get_current_time();

--- a/mux.c
+++ b/mux.c
@@ -153,7 +153,7 @@ void mux_write(uint16_t addr, uint8_t val, uint32_t trace)
 	card = (addr >> 4) & 0xF;
 
 	mode = addr & 0xf;
-	if (mode > 8) {
+	if (mode > 7) {
 		port = 0;
 		unit = card * 4;
 	} else {
@@ -203,6 +203,7 @@ void mux_write(uint16_t addr, uint8_t val, uint32_t trace)
 			fprintf(stderr, "MUX%i: TX level = %i\n", unit, val);
 		tx_ipl_request = val;
 		return;
+	case 8:
 	case 0xB:
 		// Written by CRT driver
 		if (!trace)

--- a/mux.h
+++ b/mux.h
@@ -10,8 +10,7 @@ struct MuxUnit
         unsigned char status;
         unsigned char lastc;
         int baud;
-        uint64_t tx_finish_time;
-        uint64_t rx_finish_time;
+        unsigned char tx_done;
 };
 
 /* Status register bits */
@@ -22,12 +21,16 @@ struct MuxUnit
 /* Interrupt status register bits */
 #define MUX_IRQ_RX 0
 #define MUX_IRQ_TX 1
+#define MUX_UNIT_MASK 0x06
 
 void mux_init(void);
 void mux_attach(unsigned unit, int in_fd, int out_fd);
-void tty_init(void);
-void net_init(unsigned short port);
 void mux_poll(unsigned trace);
 
 void mux_write(uint16_t addr, uint8_t val, uint32_t trace);
 uint8_t mux_read(uint16_t addr, uint32_t trace);
+
+void mux_set_read_ready(unsigned unit, unsigned trace);
+void mux_set_write_ready(unsigned unit, unsigned trace);
+
+void mux_poll_fds(struct MuxUnit* mux, unsigned trace);


### PR DESCRIPTION
MUX emulation is now completely stateful and emulates the hardware much more closely. CPU interrupts are stored as a bitmask, providing for multiple pending IPLs