### PR TITLE
Reimplement Mux timings

### DIFF
--- a/console.c
+++ b/console.c
@@ -108,20 +108,14 @@ void mux_poll_fds(struct MuxUnit* mux, unsigned trace)
 
 	for (unit = 0; unit < NUM_MUX_UNITS; unit++) {
 		int ifd = mux[unit].in_fd;
-		int ofd = mux[unit].out_fd;
 
 		/* Do not waste time repetitively polling ports,
 		 * which we know are ready.
 		 */
-		if (!(ifd == -1 || mux[unit].status & MUX_RX_READY)) {
+		if (!(ifd == -1 || mux[unit].status & MUX_RX_READY || mux[unit].rx_ready_time)) {
 			FD_SET(ifd, &i);
 			if (ifd >= max_fd)
 				max_fd = ifd + 1;
-		}
-		if (!(ofd == -1 || mux[unit].status & MUX_TX_READY)) {
-			FD_SET(ofd, &o);
-			if (ofd >= max_fd)
-				max_fd = ofd + 1;
 		}
 	}
 
@@ -132,14 +126,8 @@ void mux_poll_fds(struct MuxUnit* mux, unsigned trace)
 
 	for (unit = 0; unit < NUM_MUX_UNITS; unit++) {
 		int ifd = mux[unit].in_fd;
-		int ofd = mux[unit].out_fd;
 
 		if (ifd != -1 && FD_ISSET(ifd, &i))
 			mux_set_read_ready(unit, trace);
-		/* Unconnected ports still send their data to nowhere,
-		 * (imagine an unplugged connector), so they still becone READY
-		 */
-		if (ofd == -1 || FD_ISSET(ofd, &o))
-			mux_set_write_ready(unit, trace);
 	}
 }

--- a/console_win32.c
+++ b/console_win32.c
@@ -98,7 +98,6 @@ void mux_poll_fds(struct MuxUnit* mux, unsigned trace)
 
 	for (unit = 0; unit < NUM_MUX_UNITS; unit++) {
 		int ifd = mux[unit].in_fd;
-		int ofd = mux[unit].out_fd;
 
 		/* Do not waste time repetitively polling ports,
 		 * which we know are ready.
@@ -106,12 +105,6 @@ void mux_poll_fds(struct MuxUnit* mux, unsigned trace)
 		if (!(ifd == -1 || mux[unit].status & MUX_RX_READY)) {
                         if (tty_check_readable(ifd))
                                 mux_set_read_ready(unit, trace);
-		}
-                if (ofd == -1) {
-                        mux_set_write_ready(unit, trace);
-                } else if (!(mux[unit].status & MUX_TX_READY)) {
-                        if (tty_check_writable(ofd))
-                                mux_set_write_ready(unit, trace);
 		}
 	}
 }

--- a/cpu6.h
+++ b/cpu6.h
@@ -26,6 +26,8 @@
 #define C		12	/* Flags ? */
 #define P		14	/* PC */
 
+#define ONE_SECOND_NS 1000000000.0
+
 extern uint8_t mem_read8(uint32_t addr);
 extern uint8_t mem_read8_debug(uint32_t addr);
 extern uint8_t mmu_mem_read8(uint16_t addr);

--- a/mux.h
+++ b/mux.h
@@ -11,6 +11,8 @@ struct MuxUnit
         unsigned char lastc;
         int baud;
         unsigned char tx_done;
+        uint64_t rx_ready_time;
+        uint64_t tx_done_time;
 };
 
 /* Status register bits */
@@ -31,6 +33,5 @@ void mux_write(uint16_t addr, uint8_t val, uint32_t trace);
 uint8_t mux_read(uint16_t addr, uint32_t trace);
 
 void mux_set_read_ready(unsigned unit, unsigned trace);
-void mux_set_write_ready(unsigned unit, unsigned trace);
 
 void mux_poll_fds(struct MuxUnit* mux, unsigned trace);


### PR DESCRIPTION
*Better this time*

Currently hardcoded to 9600 baud.

In my experience, it's very important to have interrupt timings that are at least somewhat accurate.

Instant interrupts should be avoided at all costs (unless they are actually instant on hardware)