### PR TITLE
Realistic disk timings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,12 @@ all: centurion
 CFLAGS = -g3 -Wall -pedantic
 
 centurion: centurion.o cpu6.o disassemble.o dsk.o hawk.o math128.o mux.o \
-           cbin.o cbin_load.o $(SYS_OBJS)
+           cbin.o cbin_load.o scheduler.o $(SYS_OBJS)
 
-centurion.o: centurion.c centurion.h console.h cpu6.h disassemble.h dma.h dsk.h math128.o mux.h
+centurion.o: centurion.c centurion.h console.h cpu6.h disassemble.h dma.h \
+            dsk.h math128.o mux.h scheduler.h
+
+scheduler.o: scheduler.c scheduler.h cpu6.h
 
 console.o : console.c console.h mux.h
 
@@ -26,9 +29,9 @@ cpu6.o : cpu6.c cpu6.h
 
 disassemble.o: disassemble.c disassemble.h cpu6.h
 
-dsk.o: dsk.c dsk.h hawk.h dma.h
+dsk.o: dsk.c dsk.h hawk.h dma.h scheduler.h cpu6.h
 
-hawk.o: hawk.c hawk.h
+hawk.o: hawk.c hawk.h scheduler.h
 
 cbin.o: cbin.h
 
@@ -36,7 +39,7 @@ cbin_load.o: cpu6.h cbin.h
 
 math128.o: math128.h
 
-mux.o : centurion.h mux.h console.h cpu6.h
+mux.o : centurion.h mux.h console.h cpu6.h scheduler.h
 
 clean:
 	rm -f centurion *.o *~

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ all: centurion
 
 CFLAGS = -g3 -Wall -pedantic
 
-centurion: centurion.o cpu6.o disassemble.o hawk.o math128.o mux.o cbin.o \
-           cbin_load.o $(SYS_OBJS)
+centurion: centurion.o cpu6.o disassemble.o dsk.o hawk.o math128.o mux.o \
+           cbin.o cbin_load.o $(SYS_OBJS)
 
-centurion.o: centurion.c centurion.h console.h cpu6.h disassemble.h dma.h hawk.h math128.o mux.h
+centurion.o: centurion.c centurion.h console.h cpu6.h disassemble.h dma.h dsk.h math128.o mux.h
 
 console.o : console.c console.h mux.h
 
@@ -26,7 +26,9 @@ cpu6.o : cpu6.c cpu6.h
 
 disassemble.o: disassemble.c disassemble.h cpu6.h
 
-hawk.o: hawk.c hawk.h dma.h
+dsk.o: dsk.c dsk.h hawk.h dma.h
+
+hawk.o: hawk.c hawk.h
 
 cbin.o: cbin.h
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ cbin_load.o: cpu6.h cbin.h
 
 math128.o: math128.h
 
-mux.o : centurion.h mux.h
+mux.o : centurion.h mux.h console.h cpu6.h
 
 clean:
 	rm -f centurion *.o *~

--- a/centurion.c
+++ b/centurion.c
@@ -14,7 +14,7 @@
 #include "console.h"
 #include "cpu6.h"
 #include "dma.h"
-#include "hawk.h"
+#include "dsk.h"
 #include "mux.h"
 #include "cbin_load.h"
 
@@ -507,7 +507,7 @@ static uint8_t io_read8(uint16_t addr)
 	if (addr == 0xF110)
 		return switches;
 	if (addr >= 0xF140 && addr <= 0xF14F)
-		return hawk_read(addr, trace & TRACE_DSK);
+		return dsk_read(addr, trace & TRACE_DSK);
 	if (addr >= 0xF200 && addr <= 0xF21F)
 		return mux_read(addr, trace & TRACE_MUX);
 	fprintf(stderr, "%04X: Unknown I/O read %04X\n", cpu6_pc(), addr);
@@ -526,7 +526,7 @@ static void io_write8(uint16_t addr, uint8_t val)
 		hexdisplay(addr, val);
 		return;
 	} else if (addr >= 0xF140 && addr <= 0xF14F) {
-		hawk_write(addr, val, trace & TRACE_DSK);
+		dsk_write(addr, val, trace & TRACE_DSK);
 		return;
 	} else if (addr >= 0xF200 && addr <= 0xF21F) {
 		mux_write(addr, val, trace & TRACE_MUX);
@@ -772,7 +772,7 @@ int main(int argc, char *argv[])
 		load_rom("Diag_F4_1133CMD.BIN", 0x09800, 0x0800);
 	}
 
-	hawk_init();
+	dsk_init();
 	cpu6_init();
 
 	if (boot_file != NULL) {

--- a/centurion.c
+++ b/centurion.c
@@ -22,7 +22,7 @@
 static unsigned finch;		/* Finch or original FDC */
 
 volatile unsigned int emulator_done;
-static uint64_t cpu_timestamp_ns = 0;
+static int64_t cpu_timestamp_ns = 0;
 
 #define TRACE_MEM_RD	1
 #define TRACE_MEM_WR	2
@@ -638,7 +638,7 @@ void mem_write16_debug(uint32_t addr, uint16_t val)
 	mem_write8_debug(addr+1, val & 0xff);
 }
 
-uint64_t get_current_time() {
+int64_t get_current_time() {
 	return cpu_timestamp_ns;
 }
 

--- a/centurion.c
+++ b/centurion.c
@@ -33,6 +33,7 @@ static uint64_t cpu_timestamp_ns = 0;
 #define TRACE_PARITY	64
 #define TRACE_MUX	128
 #define TRACE_DSK       256
+#define TRACE_SCHEDULER 512
 
 unsigned int trace = 0;
 
@@ -850,7 +851,7 @@ int main(int argc, char *argv[])
 		/* Update peripherals state */
 		mux_poll(trace & TRACE_MUX);
 
-		run_scheduler(cpu_timestamp_ns);
+		run_scheduler(cpu_timestamp_ns, trace & TRACE_SCHEDULER);
 		throttle_emulation(cpu_timestamp_ns);
 
 		instruction_count++;

--- a/centurion.c
+++ b/centurion.c
@@ -825,7 +825,8 @@ int main(int argc, char *argv[])
 					fprintf(stderr, "DMA stalled\n");
 					exit(-1);
 				}
-				cpu_timestamp_ns = next;
+				if (next > cpu_timestamp_ns)
+					cpu_timestamp_ns = next;
 				run_scheduler(cpu_timestamp_ns, trace & TRACE_SCHEDULER);
 			}
 			hawk_dma_done();

--- a/centurion.c
+++ b/centurion.c
@@ -17,6 +17,7 @@
 #include "dsk.h"
 #include "mux.h"
 #include "cbin_load.h"
+#include "scheduler.h"
 
 static unsigned finch;		/* Finch or original FDC */
 
@@ -849,6 +850,7 @@ int main(int argc, char *argv[])
 		/* Update peripherals state */
 		mux_poll(trace & TRACE_MUX);
 
+		run_scheduler(cpu_timestamp_ns);
 		throttle_emulation(cpu_timestamp_ns);
 
 		instruction_count++;

--- a/centurion.c
+++ b/centurion.c
@@ -807,6 +807,9 @@ int main(int argc, char *argv[])
 		}
 	}
 
+	throttle_init();
+	throttle_set_speed(1.0);
+
 	while (!emulator_done) {
 		cpu6_execute_one(trace & TRACE_CPU);
 		if (cpu6_halted())
@@ -845,6 +848,8 @@ int main(int argc, char *argv[])
 		}
 		/* Update peripherals state */
 		mux_poll(trace & TRACE_MUX);
+
+		throttle_emulation(cpu_timestamp_ns);
 
 		instruction_count++;
 		if (terminate_at && instruction_count >= terminate_at) {

--- a/console.h
+++ b/console.h
@@ -1,2 +1,10 @@
+#pragma once
+
+#include <stdint.h>
+
 void tty_init(void);
 void net_init(unsigned short port);
+
+void throttle_emulation(uint64_t expected_time_ns);
+void throttle_init();
+void throttle_set_speed(float speed);

--- a/console_win32.c
+++ b/console_win32.c
@@ -103,3 +103,16 @@ void mux_poll_fds(unsigned trace)
                         mux_set_read_ready(unit, trace);
 	}
 }
+
+
+void throttle_emulation(uint64_t expected_time_ns) {
+        // Unimplemented
+}
+
+void throttle_init() {
+        // Unimplemented
+}
+
+void throttle_set_speed(float speed) {
+        // Unimplemented
+}

--- a/cpu6.c
+++ b/cpu6.c
@@ -98,6 +98,10 @@ uint8_t dma_write_cycle(void)
 	return r;
 }
 
+uint16_t cpu6_dma_count(void) {
+	return ~dma_count;
+}
+
 /*
  *	When packed into C, the flags live in the upper 4 bits of the low byte
  */

--- a/cpu6.c
+++ b/cpu6.c
@@ -102,6 +102,17 @@ uint16_t cpu6_dma_count(void) {
 	return ~dma_count;
 }
 
+void cpu6_dma_write(uint8_t byte) {
+	/* DMA is done when it incs to 0 */
+	if (dma_enable == 0 || ++dma_count == 0) {
+		dma_enable = 0;
+		return;
+	}
+	if (dma_enable) {
+		mem_write8(dma_addr++, byte);
+	}
+}
+
 /*
  *	When packed into C, the flags live in the upper 4 bits of the low byte
  */

--- a/cpu6.c
+++ b/cpu6.c
@@ -104,12 +104,14 @@ uint16_t cpu6_dma_count(void) {
 
 void cpu6_dma_write(uint8_t byte) {
 	/* DMA is done when it incs to 0 */
-	if (dma_enable == 0 || ++dma_count == 0) {
-		dma_enable = 0;
+	if (dma_enable == 0) {
 		return;
 	}
 	if (dma_enable) {
 		mem_write8(dma_addr++, byte);
+	}
+	if (++dma_count == 0xffff) {
+		dma_enable = 0;
 	}
 }
 

--- a/cpu6.h
+++ b/cpu6.h
@@ -26,8 +26,6 @@
 #define C		12	/* Flags ? */
 #define P		14	/* PC */
 
-#define ONE_SECOND_NS 1000000000.0
-
 extern uint8_t mem_read8(uint32_t addr);
 extern uint8_t mem_read8_debug(uint32_t addr);
 extern uint16_t mem_read16_debug(uint32_t addr);

--- a/cpu6.h
+++ b/cpu6.h
@@ -52,3 +52,4 @@ extern void cpu_assert_irq(unsigned ipl);
 extern void cpu_deassert_irq(unsigned ipl);
 extern void advance_time(uint64_t nanoseconds);
 extern uint64_t get_current_time();
+extern uint16_t cpu6_dma_count(void);

--- a/cpu6.h
+++ b/cpu6.h
@@ -50,3 +50,5 @@ extern void cpu_assert_irq(unsigned ipl);
 extern void cpu_deassert_irq(unsigned ipl);
 extern void advance_time(uint64_t nanoseconds);
 extern uint16_t cpu6_dma_count(void);
+extern void cpu6_dma_write(uint8_t);
+extern uint8_t cpu6_dma_read(void);

--- a/cpu6.h
+++ b/cpu6.h
@@ -49,5 +49,4 @@ extern void cpu6_init(void);
 extern void cpu_assert_irq(unsigned ipl);
 extern void cpu_deassert_irq(unsigned ipl);
 extern void advance_time(uint64_t nanoseconds);
-extern uint64_t get_current_time();
 extern uint16_t cpu6_dma_count(void);

--- a/dsk.c
+++ b/dsk.c
@@ -1,0 +1,373 @@
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "cpu6.h"
+#include "dma.h"
+#include "dsk.h"
+#include "hawk.h"
+
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
+
+/* DSK: A controller for the CDC 9427H "Hawk" drive
+ *
+ * Split across two cards: DSK/AUT and DSKII
+ *
+ *	F140	unit select
+ *	F141	}
+ *	F142	}	C/H/S as xxCC_CCCC_CCCH_SSSS
+ *  F143    Write enable bitmask
+ *  F144    Controller status
+ *  F145    Unit status
+ *	F148 W	command
+ *	F148 R  status	bit 0 is some kind of busy/accept
+ *
+ *	Command codes
+ *	0:		Read
+ *	1:		Write
+ *	2:		Seek
+ *	3:		Restore
+ *
+ *	The Hawk interface seems to be an oddity as it doesn't appear to use
+ *	the Fin Fout Busy style interface and sequencer but something smarter
+ *	of its own.
+ *
+ *
+ */
+
+/* I've taken the number from the ceiling */
+#define NUM_HAWK_UNITS 8
+
+// F140 selected unit
+static uint8_t dsk_selected_unit;
+
+// F141/F142 selected sector
+// bits are xxCC_CCCC_CCCH_SSSS
+static uint16_t dsk_selected_sector;
+
+
+// Busy
+// Controller State machine is processing a command
+static uint8_t dsk_busy;
+
+// Format Error
+// Controller couldn't find the sync pattern before address or data.
+// Sync pattern is ~87 zeros then a one
+static uint8_t dsk_fmt_err;
+
+// Addr Error
+// Controller read 16bit address at start of sector, and it was for the
+// it didn't match the controllers sector register (F141/F142)
+static uint8_t dsk_addr_err;
+
+// Timeout Error
+// Controller state machine timed out.
+// For reads/writes, It didn't see correct sector index from hawk unit.
+// For seeks/rtz, It probally didn't see on_cyl from unit
+static uint8_t dsk_timeout;
+
+// CRC Error
+// Controller encountered a CRC error after address read or data read.
+static uint8_t dsk_crc_error;
+
+static struct hawk_unit hawk[NUM_HAWK_UNITS];
+
+void dsk_init(void)
+{
+	int i;
+	char name[32];
+
+	for (i = 0; i < NUM_HAWK_UNITS; i++) {
+		memset(&hawk[i], 0, sizeof(hawk[i]));
+
+		sprintf(name, "hawk%u.disk", i);
+		hawk[i].fd = open(name, O_RDWR|O_BINARY);
+
+		if (hawk[i].fd > 0) {
+			// On a real drive it's more complex. But for us, if
+			// we have an image file for the unit, it's ready.
+
+			hawk[i].ready = 1;
+
+			// Hawk units automatically RTZ when first coming online
+			hawk_rtz(&hawk[i]);
+		}
+	}
+}
+
+static int hawk_get_fd(void)
+{
+	return dsk_selected_unit < NUM_HAWK_UNITS ? hawk[dsk_selected_unit].fd : -1;
+}
+
+/* F145
+ * These all appear to be status signals directly from the Hawk unit.
+ * The controller muxes this to currently selected unit
+ */
+uint8_t hawk_get_unit_status() {
+	struct hawk_unit *u = &hawk[dsk_selected_unit];
+	// Not known: addr_int, fault, seek_error
+
+	return (u->addr_ack << 0) // Guess: address acknowledge
+	     | (0           << 1)
+	     | (0           << 2)
+	     | (0           << 3)
+	     | (u->ready    << 4) // Probally the ready signal from drive
+	     | (u->on_cyl   << 5) // Head is on the correct cylinder
+	     | (0           << 6)
+	     | (u->wprotect << 7); // Write Protect bit
+}
+
+/* F144
+ * These all appear to be controller status bits.
+ */
+static uint8_t hawk_get_controller_status() {
+	// Not sure where these error bits go. Just put them everywhere.
+	// lets just put it in all these remaining bits we suspect are errors
+	uint8_t unk_error_bit = dsk_crc_error;
+
+	return (dsk_busy      << 0) // command in progress
+// WIPL ignores bit 1 after read, Bootstrap requires it to be zero after read
+	     | (0             << 1) // either write error, or not an error
+	     | (unk_error_bit << 2)
+	     | (unk_error_bit << 3)
+	     | (dsk_fmt_err   << 4) // Format Error (couldn't find preamble before address or data)
+	     | (dsk_addr_err  << 5) // Address Error (address didn't match)
+// Bootstrap loops forever unless dsk_timeout or hawk->on_cyl goes high
+	     | (dsk_timeout   << 6) // Seek error line from drive
+	     | (unk_error_bit << 7);
+}
+
+static void hawk_clear_controller_error() {
+	dsk_crc_error = 0;
+	dsk_addr_err = 0;
+	dsk_fmt_err = 0;
+	dsk_timeout = 0;
+	hawk[dsk_selected_unit].addr_ack = 0;
+}
+
+/*	"Cylinder  0 - 405
+ *	 MSB:
+
+ *		Cyl 256
+ *		Cyl 128
+ *		Cyl 64
+ *		Cyl 32
+ *		Cyl 16
+ *		Cyl 8
+ *		Cyl 4
+ *		Cyl 2
+ *		Cyl 1
+ *		Head 0/1,
+ *		Sector 8,
+ *		Sector 4,
+ *		Sector 2,
+ *		Sector 1.
+ *	 LSB
+ *
+ *       Max Cyl - 405,  Max Heads 0 /1 ,  Max Sectors 0-F .   So Max
+ *	 Tracks are 810  =   405 Cyl x two Heads with 16 sectors of 400
+ *	 bytes per track"
+ *		-- Ken Romain
+ */
+static void dsk_seek()
+{
+	unsigned unit = dsk_selected_unit;
+	unsigned sec = dsk_selected_sector & 0x0F;
+	unsigned head = !!(dsk_selected_sector & 0x10);
+	unsigned cyl = dsk_selected_sector >> 5;
+
+	if (hawk[unit].ready) {
+		hawk_seek(&hawk[unit], cyl, head, sec);
+	} else {
+		// If the hawk unit wasn't ready, then the state machine will timeout
+		dsk_timeout = 1;
+	}
+
+	// seeks are currently instant, so command completed
+	dsk_busy = 0;
+}
+
+uint8_t hawk_read_next(void)
+{
+	int fd = hawk_get_fd();
+	uint8_t c;
+
+	if (fd == -1) {
+		dsk_timeout = 1;
+	}
+	else if (read(fd, (void *)&c, 1) != 1) {
+		fprintf(stderr, "hawk I/O error\n");
+		// Treat this as if we read invalid data
+		dsk_crc_error = 1;
+	}
+	return c;
+}
+
+void hawk_write_next(uint8_t c)
+{
+	int fd = hawk_get_fd();
+
+	if (fd == -1) {
+		dsk_timeout = 1;
+	} else if (write(fd, (void *) &c, 1) != 1) {
+		fprintf(stderr, "hawk I/O error\n");
+		// Not sure if we have a write error, lets just set a few
+		dsk_crc_error = 1;
+		dsk_addr_err = 1;
+		dsk_fmt_err = 1;
+	}
+}
+
+void hawk_dma_done(void)
+{
+    hawk_set_dma(0);
+	dsk_busy = 0;
+
+	unsigned unit = dsk_selected_unit;
+
+	// The Hawk disk unit will fault if a read/write is done off cylinder
+	if (hawk[unit].on_cyl == 0) {
+		hawk[unit].fault = 1;
+	}
+
+	// If hawk is on the wrong cylinder
+	if (hawk[unit].current_track != (dsk_selected_sector >> 4)) {
+		dsk_addr_err = 1;
+	}
+}
+
+/*
+ *	Commands and registers as described by Ken Romain except status
+ *	was in a slightly different spot.
+ *
+ *	"The Hawk disk controller design (DSK/Auto & DSKII) was 6 years
+ *	 before the AMD2901 was available.  The (DSK/Auto & DSKII) is a
+ *	 simple MMIO with a TTL state machine which runs in sync with the
+ *	 Hawks Read / Write data stream to advance the state machine.
+ *
+ *	 A basic sector read from the Hawk (DSK/Auto & DSKII)  is....
+ *	 Drive select Reg.  0xF140,    Sector address Reg. 0xF141-F142
+ *	 Status Reg ( I think ) 0xF143   and Command Reg 0xF148 (00 = read,
+ *	 01 = write,  02 = seek,   03 = RTZ Return Track Zero.
+ *       The (DSK/Auto & DSKII)  Hawk sectors are 400 bytes ( 0x190) long
+ *	 and R / W can be 1 to 16 sector operations based on the total bytes
+ *	 the DMA was setup to move in /out of DRAM. "
+ *			-- Ken Romain
+ *
+ *	"For the longest time the OPSYS minimum disk file size was 16 sectors
+ *	 for 400 bytes ( being one logical disk track and also one physical
+ *	 track on the CDC 9427H Hawk drive). When we had large soft sector
+ *	 drives like the 9448 Phoenix we still kept the 400 byte logical
+ *	 sector length and padded the sector to 512 bytes."
+ *			-- Ken Romain
+ */
+static void dsk_cmd(uint8_t cmd, unsigned trace)
+{
+	if (trace)
+		fprintf(stderr, "%04X Hawk unit %02X command %02X\n", cpu6_pc(),
+			dsk_selected_unit, cmd);
+
+	// Controller errors appear to be cleared when starting a new command
+	hawk_clear_controller_error();
+
+	dsk_busy = 1;
+
+	switch (cmd) {
+	case 0:		/* Multi sector read  - 1 to 16 sectors */
+		hawk_set_dma(1);
+		break;
+	case 1:		/* Multi sector write - ditto */
+        hawk_set_dma(2);
+		break;
+	case 2:		/* Seek */
+		dsk_seek();
+		break;
+	case 3:		/* Return to Track Zero Sector (Recalibrate) */
+		hawk_rtz(&hawk[dsk_selected_unit]);
+		dsk_busy = 0;
+		break;
+	case 4:		/* Format sector - Ken thinks but not sure */
+	default:
+		fprintf(stderr, "%04X: Unknown hawk command %02X\n",
+			cpu6_pc(), cmd);
+		dsk_busy = 0;
+		break;
+	}
+}
+
+void dsk_write(uint16_t addr, uint8_t val, unsigned trace)
+{
+	switch (addr) {
+	case 0xF140:
+		dsk_selected_unit = val;
+		if (trace)
+			fprintf(stderr, "Selected hawk unit %i\n", val);
+		break;
+	case 0xF141:
+		dsk_selected_sector &= 0x00ff;
+		dsk_selected_sector |= val << 8;
+		break;
+	case 0xF142:
+		dsk_selected_sector &= 0xff00;
+		dsk_selected_sector |= val;
+		break;
+	// case 0xF143:
+		/* "It is a Write Enable Bit Mask to help protect against writing to a
+		*  disk platter in error should someone just enter a 0x1 Write Command
+		*  or 0x4 Format Command in error to 0xF148.
+		*  Layout is something like this.
+		*  0xF143  MSB     128    64   32   16    8   4   2    1    LSB
+		*  1 = Write Enable Platter = 0 drive 1
+		*  2 = Write Enable Platter = 1 drive 1
+		*  4 = Write Enable Platter = 0 drive 2
+		*  8 = Write Enable Platter = 1 drive 2
+		*  ...............
+		*  128 = Write Enable Platter = 1 drive 4
+		*  Regards, Ken R."
+		*/
+
+	case 0xF144:
+	case 0xF145:
+		/* Guess.. it's done early in boot */
+		hawk_clear_controller_error();
+		break;
+	case 0xF148:
+		dsk_cmd(val, trace);
+		break;
+	default:
+		fprintf(stderr,
+			"%04X: Unknown hawk I/O write %04X with %02X\n",
+			cpu6_pc(), addr, val);
+	}
+}
+
+uint8_t dsk_read(uint16_t addr, unsigned trace)
+{
+	uint8_t status;
+	switch (addr) {
+	case 0xF141:
+		return dsk_selected_sector >> 8;
+	case 0xF142:
+		return dsk_selected_sector & 0xff;
+	case 0xF144:
+		status = hawk_get_controller_status();
+		if (trace)
+			fprintf(stderr, "%04X: hawk controller status read | %02x\n", cpu6_pc(), status);
+		return status;
+	case 0xF145:
+		status = hawk_get_unit_status();
+		if (trace)
+			fprintf(stderr, "%04X: hawk unit status read | %02x\n", cpu6_pc(), status);
+		return status ;
+	case 0xF148:		/* Bit 0 seems to be set while it is processing */
+		return dsk_busy;
+	default:
+		fprintf(stderr, "%04X: Unknown hawk I/O read %04X\n",
+			cpu6_pc(), addr);
+		return 0xFF;
+	}
+}

--- a/dsk.c
+++ b/dsk.c
@@ -287,9 +287,11 @@ static void dsk_run_state_machine(unsigned trace, int64_t time)
 	dsk_tracing = trace;
 
 	do {
-		if (dsk_old_state != dsk_state && trace) {
-			fprintf(stderr, "DSK: state machine moved to %s\n", dsk_state_names[dsk_state]);
+		if (dsk_old_state != dsk_state) {
 			dsk_old_state = dsk_state;
+
+			if (trace)
+				fprintf(stderr, "DSK: state machine moved to %s\n", dsk_state_names[dsk_state]);
 		}
 
 		switch (dsk_state) {

--- a/dsk.c
+++ b/dsk.c
@@ -7,6 +7,7 @@
 #include "dma.h"
 #include "dsk.h"
 #include "hawk.h"
+#include "scheduler.h"
 
 #ifndef O_BINARY
 #define O_BINARY 0

--- a/dsk.h
+++ b/dsk.h
@@ -1,0 +1,11 @@
+#include <stdint.h>
+
+void dsk_init(void);
+unsigned get_hawk_dma_mode(void);
+
+uint8_t dsk_read(uint16_t addr, unsigned trace);
+void dsk_write(uint16_t addr, uint8_t val, unsigned trace);
+
+uint8_t hawk_read_next(void);
+void hawk_write_next(uint8_t c);
+void hawk_dma_done(void);

--- a/hawk.c
+++ b/hawk.c
@@ -184,8 +184,8 @@ static void hawk_rotation_event_cb(struct event_t* event, int64_t late_ns)
 
     struct hawk_unit* unit = rotation_event.unit;
 
-    uint64_t now = get_current_time();
-    hawk_update(unit, now);
+    int64_t time = get_current_time() - late_ns;
+    hawk_update(unit, time);
 
      // Copy current head position to read/write pointer
     unit->data_ptr = unit->head_pos;
@@ -194,9 +194,9 @@ static void hawk_rotation_event_cb(struct event_t* event, int64_t late_ns)
 }
 
 void hawk_wait_sector(struct hawk_unit* unit, unsigned sector) {
-    uint64_t now = get_current_time();
-    uint64_t rotation = (now + unit->rotation_offset) % (uint64_t)HAWK_ROTATION_NS;
-    uint64_t desired_rotation = HAWK_SECTOR_NS * sector;
+    int64_t now = get_current_time();
+    int64_t rotation = (now + unit->rotation_offset) % (uint64_t)HAWK_ROTATION_NS;
+    int64_t desired_rotation = HAWK_SECTOR_NS * sector;
 
     int64_t delta = desired_rotation - rotation;
     if (delta < 0)

--- a/hawk.c
+++ b/hawk.c
@@ -1,58 +1,257 @@
 
 #include "hawk.h"
+#include "scheduler.h"
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 
-void hawk_seek(struct hawk_unit* unit, unsigned cyl, unsigned head, unsigned sec)
+static void hawk_write_bits(struct hawk_unit* unit, int count, uint8_t* data);
+static void hawk_set_bits(struct hawk_unit* unit, int count, uint8_t val);
+
+struct seek_event_t {
+    struct event_t event;
+    struct hawk_unit *unit;
+    unsigned seek_error;
+};
+
+static struct seek_event_t seek_event;
+
+struct rotation_event_t {
+    struct event_t event;
+    struct hawk_unit *unit;
+    unsigned in_process;
+};
+static struct rotation_event_t rotation_event;
+
+static void hawk_seek_callback(struct event_t* event, int64_t late_ns)
+{
+    fprintf(stderr, "hawk_seek_callback\n");
+    assert(event == &seek_event.event);
+    struct hawk_unit* unit = seek_event.unit;
+
+    if (seek_event.seek_error) {
+        unit->seek_error = seek_event.seek_error;
+    }
+
+    // It's more of seek-complete than actually on_cyl.
+    // Forced to zero as soon as a seek begins.
+    // Gets set even if the seek errors out
+    unit->on_cyl = 1;
+    unit->seeking = 0;
+
+    // notify DSK emulation that something happened
+    dsk_hawk_changed(unit->unit_num);
+}
+
+// Reads entire track of data into host memory.
+// Converts from 400 byte sectors, into raw bits with gaps, sync and format info
+static int hawk_buffer_track(struct hawk_unit* unit, unsigned cyl, unsigned head) {
+    off_t offset = ((cyl << 5) | (head << 4)) * HAWK_SECTOR_BYTES;
+    uint8_t buffer[HAWK_SECTOR_BYTES];
+
+    if (lseek(unit->fd, offset, SEEK_SET) == -1) {
+        fprintf(stderr, "hawk position failed (%d,%d,0) = %lx.\n",
+            cyl, head, (long) offset);
+        return 0;
+    }
+
+    for (int sector = 0; sector < HAWK_SECTS_PER_TRK; sector++) {
+        unit->data_ptr = sector * HAWK_RAW_SECTOR_BITS;
+        // ~120 bit gap, to compensate mechanical jitter
+        hawk_set_bits(unit, HAWK_GAP_BITS, 0);
+
+        // sync. 87 zeros, followed by a one
+        hawk_set_bits(unit, HAWK_SYNC_BITS-1, 0);
+        hawk_set_bits(unit, 1, 1);
+
+        // sector address
+        uint16_t addr = (cyl << 8) | (head << 4) | sector;
+        uint16_t check_word = ~addr; // guess.
+        uint8_t addr_data[4] = {
+            (addr >> 8) & 0xff,
+            addr & 0xff,
+            (check_word >> 8) & 0xff,
+            check_word & 0xff,
+        };
+        hawk_write_bits(unit, 32, addr_data);
+
+        // second gap
+        hawk_set_bits(unit, HAWK_GAP_BITS, 0);
+
+        // another sync
+        hawk_set_bits(unit, HAWK_SYNC_BITS-1, 0);
+        hawk_set_bits(unit, 1, 1);
+
+        // sector data
+        if (read(unit->fd, buffer, HAWK_SECTOR_BYTES) != HAWK_SECTOR_BYTES) {
+            fprintf(stderr, "hawk read failed (%d,%d,%d).\n", cyl, head, sector);
+            return 0;
+        }
+        hawk_write_bits(unit, HAWK_SECTOR_BYTES * 8, buffer);
+
+        // CRC
+        // TODO: proper CRC function
+        uint8_t crc[2] = { 0xcc, 0xcc };
+        hawk_write_bits(unit, 16, crc);
+
+        // Trailer
+        hawk_set_bits(unit, HAWK_GAP_BITS / 2, 0);
+    }
+
+    return 1;
+}
+
+
+void hawk_seek(struct hawk_unit* unit, unsigned cyl, unsigned head)
 {
     // The hawk unit only has 9 lines for cylinder addr, so address really
     // should get masked.
     // OR, is DSK expected to throw an error before seeking?
 
-    // In reality, the hawk unit doesn't receive the sector, it only seeks
-    // to a cylinder and selects the correct head.
-    // It then streams out raw bits off the disk, along with pluses for
-    // sector/track begin and sector index
-    // The controller is expected to wait for it's request sector, verify
-    // the address marker and then catch the data.
-    //
-    // But we simplify things slightly.
+    if (unit->seeking)
+        return;
 
-	unit->on_cyl = 0;
-	unit->addr_ack = 0;
-	unit->addr_int = 0;
+    unit->seeking = 1;
+    unit->addr_ack = 0;
+    unit->addr_int = 0;
     unit->current_track = cyl << 1 | head;
 
-    unsigned offset = (cyl << 5) | (head << 4) | sec;
-    offset *= HAWK_SECTOR_SIZE;
+    unit->on_cyl = 0;
 
-    if (cyl >= HAWK_NUM_CYLINDERS) {
+
+    off_t offset = (cyl << 5) | (head << 4) * HAWK_SECTOR_BYTES;
+    offset *= HAWK_SECTOR_BYTES;
+
+        if (cyl >= HAWK_NUM_CYLINDERS) {
         // Tried to seek past end of disk
         unit->addr_int = 1;
         return;
     }
 
-    if (lseek(unit->fd, offset, SEEK_SET) == -1) {
-        fprintf(stderr, "hawk position failed (%d,%d,%d) = %lx.\n",
-            cyl, head, sec, (long) offset);
+    // According to specs, the average track-to-track seek time is 7.5ms.
+    // TODO: Accurate seek times
+    seek_event.event.delta_ns = 7.5 * ONE_MILISECOND_NS;
+    seek_event.event.callback = hawk_seek_callback;
+    seek_event.unit = unit;
+    seek_event.seek_error = 0;
 
-        // Lets treat this as some kind of seek error
-        unit->seek_error = 1;
-    } else {
-        // Successful seek
-        unit->on_cyl = 1;
-        unit->addr_ack = 1;
+    // To simplify emulation, slurp the whole track into host memory
+    if (!hawk_buffer_track(unit, cyl, head)) {
+        // According to manual, a Seek Error is generated if the carriage
+        // goes beyond end of travel or on cyl is not present 0.5 seconds
+        // after initiation of CA Strobe or RTZ
+
+        // we will emulate our IO error as 500ms timeout
+        seek_event.seek_error = 1;
+        seek_event.event.delta_ns = 500 * ONE_MILISECOND_NS;
     }
+
+    unit->addr_ack = 1;
+    schedule_event(&seek_event.event);
+    fprintf(stderr, "Scheduled seek finished in %f ms\n", (double)seek_event.event.delta_ns / ONE_MILISECOND_NS);
 }
+
 
 void hawk_rtz(struct hawk_unit* unit)
 {
-    // According to documentation, The Hawk drive unit will clear any seek
+    // According to manual, The Hawk drive unit will clear any seek
     // errors and faults on RTZS
     unit->seek_error = 0;
     unit->fault = 0;
+    unit->seeking = 0;
 
-    hawk_seek(unit, 0, 0, 0);
+    hawk_seek(unit, 0, 0);
+}
+
+void hawk_update(struct hawk_unit* unit, uint64_t now) {
+    uint64_t rotation = (now + unit->rotation_offset) % (uint64_t)HAWK_ROTATION_NS;
+
+    unit->head_pos = rotation * HAWK_BIT_NS;
+    unit->sector_addr = rotation / HAWK_SECTOR_NS;
+}
+
+int hawk_remaining_bits(struct hawk_unit* unit, uint64_t time) {
+    hawk_update(unit, time);
+    return unit->head_pos - unit->data_ptr;
+}
+
+static void hawk_rotation_event_cb(struct event_t* event, int64_t late_ns)
+{
+    assert(event == &rotation_event.event);
+    rotation_event.in_process = 0;
+
+    struct hawk_unit* unit = rotation_event.unit;
+
+    uint64_t now = get_current_time();
+    hawk_update(unit, now);
+
+     // Copy current head position to read/write pointer
+    unit->data_ptr = unit->head_pos;
+    fprintf(stderr, "hawk rotation event, at sector %i\n", unit->sector_addr);
+    dsk_hawk_changed(unit->unit_num);
+}
+
+void hawk_wait_sector(struct hawk_unit* unit, unsigned sector) {
+    uint64_t now = get_current_time();
+    uint64_t rotation = (now + unit->rotation_offset) % (uint64_t)HAWK_ROTATION_NS;
+    uint64_t desired_rotation = HAWK_SECTOR_NS * sector;
+
+    int64_t delta = desired_rotation - rotation;
+    if (delta < 0)
+        delta += HAWK_ROTATION_NS;
+
+    assert(rotation_event.in_process == 0);
+
+    rotation_event.unit = unit;
+    rotation_event.in_process = 1;
+    rotation_event.event.delta_ns = delta;
+    rotation_event.event.callback = hawk_rotation_event_cb;
+
+    schedule_event(&rotation_event.event);
+    fprintf(stderr, "wait for %i, Scheduled rotation finished in %f ms\n", sector, (double)rotation_event.event.delta_ns / ONE_MILISECOND_NS);
+}
+
+void hawk_read_bits(struct hawk_unit* unit, int count, uint8_t *dest) {
+    while (1) {
+        uint8_t byte = 0;
+        for (int shift = 7; shift != 0; shift--) {
+            uint8_t bit = unit->current_track_data[unit->data_ptr++];
+            bit = bit << shift;
+            byte |= bit;
+            if (--count) {
+                *dest++ = byte;
+                return;
+            }
+        }
+        *dest++ = byte;
+    }
+}
+
+void hawk_rewind(struct hawk_unit* unit, int count) {
+    unit->data_ptr = unit->data_ptr - count;
+    if (unit->data_ptr < 0)
+        unit->data_ptr += HAWK_RAW_TRACK_BITS;
+}
+
+static void hawk_write_bits(struct hawk_unit* unit, int count, uint8_t* data) {
+    while (1) {
+        uint8_t byte = *(data++);
+        for (int shift = 7; shift != 0; shift--) {
+            if (count--)
+                return;
+
+            uint8_t bit = (byte >> shift) & 1;
+            unit->current_track_data[unit->data_ptr++] = bit;
+        }
+    }
+}
+
+static void hawk_set_bits(struct hawk_unit* unit, int count, uint8_t val) {
+    val = val & 1;
+
+    while (count--) {
+        unit->current_track_data[unit->data_ptr++] = val;
+    }
 }

--- a/hawk.c
+++ b/hawk.c
@@ -1,362 +1,58 @@
-#include <fcntl.h>
-#include <stdio.h>
-#include <unistd.h>
 
-#include "cpu6.h"
-#include "dma.h"
 #include "hawk.h"
 
-#ifndef O_BINARY
-#define O_BINARY 0
-#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
 
-/*
- *	CDC 9427H Hawk disk controller
- *	F140	unit select
- *	F141	}
- *	F142	}	C/H/S of some format
- *	F148 W	command
- *	F148 R  status	bit 0 is some kind of busy/accept
- *
- *	Command codes
- *	0:		Read
- *	1:		Write
- *	2:		Seek
- *	3:		Restore
- *
- *	The Hawk interface seems to be an oddity as it doesn't appear to use
- *	the Fin Fout Busy style interface and sequencer but something smarter
- *	of its own.
- *
- *	This is roughly complete except that we don't know what actual
- *	error codes were used, and this ignores the unit select entirely
- *	at the moment.
- */
-
-/* I've taken the number from the ceiling */
-#define NUM_HAWK_UNITS 8
-
-static uint8_t hawk_unit;
-static uint8_t hawk_sech;
-static uint8_t hawk_secl;
-
-// All these "from Hawk unit" signals are muxed to selected unit.
-
-// Ready
-// From Hawk unit.
-// High when:
-//  - This disk cartridge is installed
-//  - Spindle motor speed is correct
-//  - heads loaded
-//  - DC voltages within margin
-//  - no fault condition exists
-//  - unit selected
-//  - terminator is present and has power
-static uint8_t hawk_ready;
-
-// On Cyl (On Cylinder)
-// From Hawk unit.
-// Set when the heads have finished seeking to the desired address.
-// Also high when a seek error occurs
-static uint8_t hawk_on_cyl;
-
-// Sker (Seek Error)
-// From Hawk unit
-// Set when the unit was unable to complete a seek operation.
-// A RTZS command from the controller clears the seek error
-// condition and returns the heads to cylinder 00.
-// On Cylinder is also asserted during seek error.
-static uint8_t hawk_seek_error;
-
-// Fault
-// From Hawk unit
-// Indicates that the unit has encounterd one or more fault conditions:
-//  - more than one head selected
-//  - read and write gates true at same time
-//  - read and erase gates true at same time
-//  - controller enabled only one of the write and erase gates
-//  - low voltage
-//  - selecting fixed heads on drive without fixed disk option
-//  - Emergency retract
-//
-// Stays high until a RTZS operation.
-static uint8_t hawk_fault;
-
-// Unimplemented output signals from Hawk unit
-// Some of them probally go in status.
-//   Index (sector 0 pulse), Sector (one pulse per sector),
-//   Address Interlock (bad address), Address Acknowledge (address accepted),
-//   Wr State (Write Protect), Sector Address (upto 6 bits), Density.
-//
-// // See Page 25 of HAWK_9427_BP11_OCT80.pdf for details
-
-// Busy
-// From controller
-// This is probally only set when it's doing (or waiting to do)
-// a DMA operation. But the controller might also mix in the On Cylinder
-// line while seeking.
-static uint8_t hawk_dma_busy;
-
-// Data Error
-// This is just a stand in for error various read/write error conditions.
-// Probally mostly coming from the controllers state machine. Sector not
-// found, or CRC failed. Probally also includes the Fault line
-static uint8_t hawk_data_error;
-
-
-static int hawk_fd[NUM_HAWK_UNITS];
-
-void hawk_init(void)
+void hawk_seek(struct hawk_unit* unit, unsigned cyl, unsigned head, unsigned sec)
 {
-	int i;
-	char name[32];
+    // The hawk unit only has 9 lines for cylinder addr, so address really
+    // should get masked.
+    // OR, is DSK expected to throw an error before seeking?
 
-	for (i = 0; i < NUM_HAWK_UNITS; i++) {
-		sprintf(name, "hawk%u.disk", i);
-		/* We don't worry here is this works or not */
-		hawk_fd[i] = open(name, O_RDWR|O_BINARY);
-	}
+    // In reality, the hawk unit doesn't receive the sector, it only seeks
+    // to a cylinder and selects the correct head.
+    // It then streams out raw bits off the disk, along with pluses for
+    // sector/track begin and sector index
+    // The controller is expected to wait for it's request sector, verify
+    // the address marker and then catch the data.
+    //
+    // But we simplify things slightly.
+
+	unit->on_cyl = 0;
+	unit->addr_ack = 0;
+	unit->addr_int = 0;
+    unit->current_track = cyl << 1 | head;
+
+    unsigned offset = (cyl << 5) | (head << 4) | sec;
+    offset *= HAWK_SECTOR_SIZE;
+
+    if (cyl >= HAWK_NUM_CYLINDERS) {
+        // Tried to seek past end of disk
+        unit->addr_int = 1;
+        return;
+    }
+
+    if (lseek(unit->fd, offset, SEEK_SET) == -1) {
+        fprintf(stderr, "hawk position failed (%d,%d,%d) = %lx.\n",
+            cyl, head, sec, (long) offset);
+
+        // Lets treat this as some kind of seek error
+        unit->seek_error = 1;
+    } else {
+        // Successful seek
+        unit->on_cyl = 1;
+        unit->addr_ack = 1;
+    }
 }
 
-static int hawk_get_fd(void)
+void hawk_rtz(struct hawk_unit* unit)
 {
-	return hawk_unit < NUM_HAWK_UNITS ? hawk_fd[hawk_unit] : -1;
-}
+    // According to documentation, The Hawk drive unit will clear any seek
+    // errors and faults on RTZS
+    unit->seek_error = 0;
+    unit->fault = 0;
 
-static uint16_t hawk_get_status() {
-	// Not sure where data errors and fault goes,
-	// lets just put it in all these remaining bits we suspect are errors
-	uint8_t unk_error_bit = hawk_fault | hawk_data_error;
-
-	return (0               << 0) // Potentially four bits of current sector?
-	     | (0               << 1)
-	     | (0               << 2)
-	     | (0               << 3)
-	     | (hawk_ready      << 4) // Probally the ready signal from drive
-	     | (hawk_on_cyl     << 5) // Head is on the correct cylinder, line from drive
-	     | (0               << 6)
-	     | (0               << 7)
-	     | (hawk_dma_busy   << 8) // Read/Write/Fmt command in progress
-// WIPL ignores bit 9 after read, Bootstrap requires it to be zero after read
-	     | (0               << 9) // either write error, or not an error
-	     | (unk_error_bit  << 10)
-	     | (unk_error_bit  << 11)
-	     | (unk_error_bit  << 12)
-	     | (unk_error_bit  << 13)
-// Bootstrap loops forever unless either seek_error or on_track goes high
-	     | (hawk_seek_error << 14) // Seek error line from drive
-	     | (unk_error_bit  << 15);
-}
-
-/*	"Cylinder  0 - 405
- *	 MSB:
-
- *		Cyl 256
- *		Cyl 128
- *		Cyl 64
- *		Cyl 32
- *		Cyl 16
- *		Cyl 8
- *		Cyl 4
- *		Cyl 2
- *		Cyl 1
- *		Head 0/1,
- *		Sector 8,
- *		Sector 4,
- *		Sector 2,
- *		Sector 1.
- *	 LSB
- *
- *       Max Cyl - 405,  Max Heads 0 /1 ,  Max Sectors 0-F .   So Max
- *	 Tracks are 810  =   405 Cyl x two Heads with 16 sectors of 400
- *	 bytes per track"
- *		-- Ken Romain
- */
-static void hawk_position(void)
-{
-	unsigned sec = hawk_secl & 0x0F;
-	unsigned head = !!(hawk_secl & 0x10);
-	unsigned cyl = (hawk_sech << 3) | (hawk_secl >> 5);
-	off_t offset = cyl;
-	int fd = hawk_get_fd();
-
-	offset *= 2;
-	offset += head;
-	offset *= 16;		/* According to Ken, 16 spt */
-	offset += sec;
-	offset *= 400;
-
-	hawk_on_cyl = 0;
-	if (fd != -1) {
-		if (lseek(fd, offset, SEEK_SET) == -1) {
-			fprintf(stderr, "hawk position failed (%d,%d,%d) = %lx.\n",
-				cyl, head, sec, (long) offset);
-			hawk_seek_error = 1;
-		} else {
-			// Successful seek
-			hawk_on_cyl = 1;
-		}
-	} else {
-		hawk_seek_error = 1;
-	}
-}
-
-uint8_t hawk_read_next(void)
-{
-	int fd = hawk_get_fd();
-	uint8_t c;
-
-	if (fd == -1) {
-		hawk_data_error = 1;
-	}
-	else if (read(fd, (void *)&c, 1) != 1) {
-		fprintf(stderr, "hawk I/O error\n");
-		hawk_data_error = 1;
-	}
-	return c;
-}
-
-void hawk_write_next(uint8_t c)
-{
-	int fd = hawk_get_fd();
-
-	if (fd == -1) {
-		hawk_data_error = 1;
-	} else if (write(fd, (void *) &c, 1) != 1) {
-		fprintf(stderr, "hawk I/O error\n");
-		hawk_data_error = 1;
-	}
-}
-
-void hawk_dma_done(void)
-{
-    hawk_set_dma(0);
-	hawk_dma_busy = 0;
-
-	// The Hawk disk unit will fault if a read/write is done off cylinder
-	hawk_fault |= !hawk_on_cyl;
-}
-
-/*
- *	Commands and registers as described by Ken Romain except status
- *	was in a slightly different spot.
- *
- *	"The Hawk disk controller design (DSK/Auto & DSKII) was 6 years
- *	 before the AMD2901 was available.  The (DSK/Auto & DSKII) is a
- *	 simple MMIO with a TTL state machine which runs in sync with the
- *	 Hawks Read / Write data stream to advance the state machine.
- *
- *	 A basic sector read from the Hawk (DSK/Auto & DSKII)  is....
- *	 Drive select Reg.  0xF140,    Sector address Reg. 0xF141-F142
- *	 Status Reg ( I think ) 0xF143   and Command Reg 0xF148 (00 = read,
- *	 01 = write,  02 = seek,   03 = RTZ Return Track Zero.
- *       The (DSK/Auto & DSKII)  Hawk sectors are 400 bytes ( 0x190) long
- *	 and R / W can be 1 to 16 sector operations based on the total bytes
- *	 the DMA was setup to move in /out of DRAM. "
- *			-- Ken Romain
- *
- *	"For the longest time the OPSYS minimum disk file size was 16 sectors
- *	 for 400 bytes ( being one logical disk track and also one physical
- *	 track on the CDC 9427H Hawk drive). When we had large soft sector
- *	 drives like the 9448 Phoenix we still kept the 400 byte logical
- *	 sector length and padded the sector to 512 bytes."
- *			-- Ken Romain
- */
-static void hawk_cmd(uint8_t cmd, unsigned trace)
-{
-	if (trace)
-		fprintf(stderr, "%04X Hawk unit %02X command %02X\n", cpu6_pc(), hawk_unit, cmd);
-
-	switch (cmd) {
-	case 0:		/* Multi sector read  - 1 to 16 sectors */
-		hawk_dma_busy = 1;
-		hawk_set_dma(1);
-		break;
-	case 1:		/* Multi sector write - ditto */
-		hawk_dma_busy = 1;
-        hawk_set_dma(2);
-		break;
-	case 2:		/* Seek */
-		// Guess. Seeks probally don't set busy
-		hawk_position();
-		break;
-	case 3:		/* Return to Track Zero Sector (Recalibrate) */
-		// Slams the heads into the rubber stops, and then seeks to the first track
-
-		// According to documentation, The Hawk drive unit will clear any seek
-		// errors and faults on RTZS
-		hawk_seek_error = 0;
-		hawk_fault = 0;
-
-		// Guess, but chances are the controller also clears it's data errors on RTZS
-		hawk_data_error = 0;
-
-		// Guess. Seeks probally don't set busy
-
-		hawk_position();
-		break;
-	case 4:		/* Format sector - Ken thinks but not sure */
-	default:
-		fprintf(stderr, "%04X: Unknown hawk command %02X\n",
-			cpu6_pc(), cmd);
-		hawk_dma_busy = 0;
-		break;
-	}
-}
-
-void hawk_write(uint16_t addr, uint8_t val, unsigned trace)
-{
-	switch (addr) {
-	case 0xF140:
-		hawk_unit = val;
-		// On a real drive it's more complex. But for us, if
-		// we have an image file for the unit, it's ready.
-		hawk_ready = (hawk_get_fd() != -1);
-		if (trace)
-			fprintf(stderr, "Selected hawk unit %i\n", val);
-		break;
-	case 0xF141:
-		hawk_sech = val;
-		break;
-	case 0xF142:
-		hawk_secl = val;
-		break;
-		/* This seems to be a word. The code checks F144 bit 2 for
-		   an error situation, and after the read F144 non zero for error */
-	case 0xF144:
-	case 0xF145:
-		/* Guess.. it's done early in boot */
-		hawk_data_error = 0;
-		break;
-	case 0xF148:
-		hawk_cmd(val, trace);
-		break;
-	default:
-		fprintf(stderr,
-			"%04X: Unknown hawk I/O write %04X with %02X\n",
-			cpu6_pc(), addr, val);
-	}
-}
-
-uint8_t hawk_read(uint16_t addr, unsigned trace)
-{
-	uint8_t status;
-	switch (addr) {
-	case 0xF144:
-		status = hawk_get_status() >> 8;
-		if (trace)
-			fprintf(stderr, "%04X: hawk status read high | %02x__\n", cpu6_pc(), status);
-		return status;
-	case 0xF145:
-		status = hawk_get_status() & 0xff;
-		if (trace)
-			fprintf(stderr, "%04X: hawk status read low  | __%02x\n", cpu6_pc(), status);
-		return status ;
-	case 0xF148:		/* Bit 0 seems to be set while it is processing */
-		return hawk_dma_busy;
-	default:
-		fprintf(stderr, "%04X: Unknown hawk I/O read %04X\n",
-			cpu6_pc(), addr);
-		return 0xFF;
-	}
+    hawk_seek(unit, 0, 0, 0);
 }

--- a/hawk.h
+++ b/hawk.h
@@ -16,6 +16,7 @@
 #define HAWK_ROTATION_NS (ONE_MILISECOND_NS * 25.0)
 #define HAWK_BIT_NS (HAWK_ROTATION_NS / HAWK_RAW_TRACK_BITS)
 #define HAWK_SECTOR_NS (HAWK_ROTATION_NS / HAWK_SECTS_PER_TRK)
+#define HAWK_SECTOR_PULSE_NS (2000) // Complete guess
 
 struct hawk_unit {
 // Output signals
@@ -69,13 +70,17 @@ struct hawk_unit {
 	// sending a write_inhibit signal to drive
 	uint8_t wprotect;
 
+	// Sector Pulse
+	// high when head is at the start of a sector
+	uint8_t sector_pulse;
+
 	// Sector Address
 	// The current sector under head
 	uint8_t sector_addr;
 
 	// Unimplemented output signals from Hawk unit
 	// Some of them probally go in status.
-	//   Index (sector 0 pulse), Sector (one pulse per sector), Density
+	//   Index (sector 0 pulse), Density
 	//
 	// // See Page 25 of HAWK_9427_BP11_OCT80.pdf for details
 
@@ -100,9 +105,11 @@ void hawk_seek(struct hawk_unit* unit, unsigned cyl, unsigned head);
 void hawk_rtz(struct hawk_unit* unit);
 int hawk_remaining_bits(struct hawk_unit* unit, uint64_t time);
 void hawk_read_bits(struct hawk_unit* unit, int count, uint8_t *dest);
+uint8_t hawk_read_byte(struct hawk_unit* unit);
+uint16_t hawk_read_word(struct hawk_unit* unit);
 void hawk_rewind(struct hawk_unit* unit, int count); // cheating
 void hawk_wait_sector(struct hawk_unit* unit, unsigned sector);
 void hawk_update(struct hawk_unit* unit, int64_t now);
 
 // Callback to dsk
-void dsk_hawk_changed(unsigned unit);
+void dsk_hawk_changed(unsigned unit, int64_t time);

--- a/hawk.h
+++ b/hawk.h
@@ -22,6 +22,10 @@
 #define HAWK_DATACELL_CLOCK_BIT 0x10
 
 struct hawk_drive {
+	struct event_t event;
+	unsigned event_type;
+	char event_name_string[16];
+
 // Output signals
 	// Ready
 	// High when:

--- a/hawk.h
+++ b/hawk.h
@@ -1,11 +1,79 @@
+#pragma once
+
 #include <stdint.h>
 
-void hawk_init(void);
-unsigned get_hawk_dma_mode(void);
+#define HAWK_NUM_CYLINDERS 406
+#define HAWK_NUM_HEADS 2
+#define HAWK_SECTS_PER_TRK 16 // Configurable, but Centurion used 16
 
-uint8_t hawk_read(uint16_t addr, unsigned trace);
-void hawk_write(uint16_t addr, uint8_t val, unsigned trace);
+#define HAWK_SECTOR_SIZE 400
 
-uint8_t hawk_read_next(void);
-void hawk_write_next(uint8_t c);
-void hawk_dma_done(void);
+struct hawk_unit {
+// Output signals
+	// Ready
+	// High when:
+	//  - This disk cartridge is installed
+	//  - Spindle motor speed is correct
+	//  - heads loaded
+	//  - DC voltages within margin
+	//  - no fault condition exists
+	//  - unit selected
+	//  - terminator is present and has power
+	uint8_t ready;
+
+	// On Cyl (On Cylinder)
+    // Cleared as soon as a seek begins.
+	// Set when the heads have finished seeking to the desired address.
+	// Also high when a seek error occurs
+	uint8_t on_cyl;
+
+	// Sker (Seek Error)
+	// Set when the unit was unable to complete a seek operation.
+	// A RTZS command from the controller clears the seek error
+	// condition and returns the heads to cylinder 00.
+	// On Cylinder is also asserted during seek error.
+	uint8_t seek_error;
+
+	// Fault
+	// Indicates that the unit has encountered one or more fault conditions:
+	//  - more than one head selected
+	//  - read and write gates true at same time
+	//  - read and erase gates true at same time
+	//  - controller enabled only one of the write and erase gates
+	//  - low voltage
+	//  - selecting fixed heads on drive without fixed disk option
+	//  - Emergency retract
+	//
+	// Stays high until a RTZS operation.
+	uint8_t fault;
+
+	// Address Acknowledge
+	// Seek address accepted
+	uint8_t addr_ack;
+
+	// Address Interlock
+    // cylinder address was larger than the number of cylinders on the disk
+	uint8_t addr_int;
+
+	// Write Protect
+	// From Hawk unit
+	// Either the unit's write protect switch is on, or the controller is
+	// sending a write_inhibit signal to drive
+	uint8_t wprotect;
+
+	// Unimplemented output signals from Hawk unit
+	// Some of them probally go in status.
+	//   Index (sector 0 pulse), Sector (one pulse per sector),
+	//   Sector Address (upto 6 bits), Density.
+	//
+	// // See Page 25 of HAWK_9427_BP11_OCT80.pdf for details
+
+	// File handle of image file
+	int fd;
+
+	// current cylinder << 1 | head
+	uint16_t current_track;
+};
+
+void hawk_seek(struct hawk_unit* unit, unsigned cyl, unsigned head, unsigned sec);
+void hawk_rtz(struct hawk_unit* unit);

--- a/hawk.h
+++ b/hawk.h
@@ -112,6 +112,9 @@ struct hawk_drive {
 	int32_t data_ptr;
 	int32_t head_pos;
 	uint64_t rotation_offset;
+
+	// For unrealistically instant seeking, and teleporting rotations
+	unsigned instant_read;
 };
 
 void hawk_init(struct hawk_drive* unit, unsigned drive_num, int fd1, int fd2);

--- a/hawk.h
+++ b/hawk.h
@@ -102,7 +102,7 @@ int hawk_remaining_bits(struct hawk_unit* unit, uint64_t time);
 void hawk_read_bits(struct hawk_unit* unit, int count, uint8_t *dest);
 void hawk_rewind(struct hawk_unit* unit, int count); // cheating
 void hawk_wait_sector(struct hawk_unit* unit, unsigned sector);
-void hawk_update(struct hawk_unit* unit, uint64_t now);
+void hawk_update(struct hawk_unit* unit, int64_t now);
 
 // Callback to dsk
 void dsk_hawk_changed(unsigned unit);

--- a/hawk.h
+++ b/hawk.h
@@ -21,7 +21,7 @@
 #define HAWK_DATACELL_DATA_BIT  0x01
 #define HAWK_DATACELL_CLOCK_BIT 0x10
 
-struct hawk_unit {
+struct hawk_drive {
 // Output signals
 	// Ready
 	// High when:
@@ -90,11 +90,13 @@ struct hawk_unit {
 	uint8_t seeking;
 
 	// File handle of image file
-	int fd;
-	unsigned unit_num;
+	int fd_removable;
+	int fd_fixed;
 
-	// current cylinder << 1 | head
-	uint16_t current_track;
+	// assigned drive number
+	unsigned drive_num;
+
+	unsigned selected; // removable or fixed
 
 	// Datacells for current track
 	// Wastefully store 1 bit per byte.
@@ -108,16 +110,18 @@ struct hawk_unit {
 	uint64_t rotation_offset;
 };
 
-void hawk_seek(struct hawk_unit* unit, unsigned cyl, unsigned head);
-void hawk_rtz(struct hawk_unit* unit);
-int hawk_remaining_bits(struct hawk_unit* unit, uint64_t time);
-void hawk_read_bits(struct hawk_unit* unit, int count, uint8_t *dest);
-uint8_t hawk_read_byte(struct hawk_unit* unit);
-uint16_t hawk_read_word(struct hawk_unit* unit);
-void hawk_rewind(struct hawk_unit* unit, int count); // cheating
-void hawk_wait_sector(struct hawk_unit* unit, unsigned sector);
-int hawk_wait_sync(struct hawk_unit* unit);
-void hawk_update(struct hawk_unit* unit, int64_t now);
+void hawk_init(struct hawk_drive* unit, unsigned drive_num, int fd1, int fd2);
+void hawk_setfd(struct hawk_drive* unit, unsigned fixed, int fd);
+void hawk_seek(struct hawk_drive* unit, unsigned fixed, unsigned cyl, unsigned head);
+void hawk_rtz(struct hawk_drive* unit, unsigned fixed);
+int hawk_remaining_bits(struct hawk_drive* unit, uint64_t time);
+void hawk_read_bits(struct hawk_drive* unit, int count, uint8_t *dest);
+uint8_t hawk_read_byte(struct hawk_drive* unit);
+uint16_t hawk_read_word(struct hawk_drive* unit);
+void hawk_rewind(struct hawk_drive* unit, int count); // cheating
+void hawk_wait_sector(struct hawk_drive* unit, unsigned sector);
+int hawk_wait_sync(struct hawk_drive* unit);
+void hawk_update(struct hawk_drive* unit, int64_t now);
 
 // Callback to dsk
 void dsk_hawk_changed(unsigned unit, int64_t time);

--- a/mux.c
+++ b/mux.c
@@ -8,6 +8,7 @@
 #include "console.h"
 #include "cpu6.h"
 #include "mux.h"
+#include "scheduler.h"
 
 struct MuxUnit mux[NUM_MUX_UNITS];
  // 0 disables interrupts

--- a/mux.c
+++ b/mux.c
@@ -316,7 +316,7 @@ void mux_set_read_ready(unsigned unit, unsigned trace)
 }
 
 void mux_process_events(unsigned unit, unsigned trace) {
-	uint64_t time = get_current_time();
+	int64_t time = get_current_time();
 
 	if (mux[unit].rx_ready_time && mux[unit].rx_ready_time <= time) {
 		assert(mux[unit].in_fd != -1);

--- a/mux.h
+++ b/mux.h
@@ -11,8 +11,8 @@ struct MuxUnit
         unsigned char lastc;
         int baud;
         unsigned char tx_done;
-        uint64_t rx_ready_time;
-        uint64_t tx_done_time;
+        int64_t rx_ready_time;
+        int64_t tx_done_time;
 };
 
 /* Status register bits */

--- a/scheduler.c
+++ b/scheduler.c
@@ -1,0 +1,72 @@
+#include "scheduler.h"
+#include "cpu6.h"
+
+#include <stdlib.h>
+#include <assert.h>
+
+static struct event_t* event_list = NULL;
+static uint64_t next_event = UINT64_MAX;
+
+void schedule_event(struct event_t *event)
+{
+    uint64_t now = get_current_time();
+    int64_t scheduled = get_current_time() + event->delta_ns;
+    assert(scheduled > now);
+
+    if (event->next != NULL)
+        cancel_event(event);
+
+    event->scheduled_ns = scheduled;
+
+    if (!event_list) {
+        event->next = NULL;
+        event_list = event;
+        next_event = scheduled;
+        return;
+    }
+
+    struct event_t* item = event_list;
+
+    while (item && item->scheduled_ns < scheduled) {
+        item = item->next;
+    }
+    event->next = item->next;
+    item->next = event;
+}
+
+void run_scheduler(uint64_t current_time)
+{
+    if (next_event > current_time)
+        return;
+
+    assert(event_list);
+
+    while (next_event <= current_time) {
+        // Pop event
+        struct event_t* event = event_list;
+        event_list = event_list->next;
+        event->next = NULL;
+
+        // Update next_event
+        next_event = (event_list == NULL) ? UINT64_MAX : event_list->scheduled_ns;
+
+        // Run callback
+        event->callback(event, current_time - event->scheduled_ns);
+    }
+}
+
+
+void cancel_event(struct event_t *event)
+{
+    struct event_t** next_ptr = &event_list;
+
+    while(*next_ptr != NULL) {
+        struct event_t* next = *next_ptr;
+        if (next == event) {
+            *next_ptr = next->next;
+            event->next = NULL;
+            return;
+        }
+        next_ptr = &next->next;
+    }
+}

--- a/scheduler.c
+++ b/scheduler.c
@@ -3,39 +3,57 @@
 
 #include <stdlib.h>
 #include <assert.h>
+#include <stdio.h>
 
 static struct event_t* event_list = NULL;
 static uint64_t next_event = UINT64_MAX;
+static unsigned trace_schedule = 0;
+
+static void update_next_event()
+{
+    // Update next_event
+    next_event = (event_list == NULL) ? UINT64_MAX : event_list->scheduled_ns;
+
+}
 
 void schedule_event(struct event_t *event)
 {
     uint64_t now = get_current_time();
     int64_t scheduled = get_current_time() + event->delta_ns;
-    assert(scheduled > now);
+    assert(scheduled >= now);
 
-    if (event->next != NULL)
+    if (trace_schedule) {
+        long now_seconds = now / ONE_SECOND_NS;
+        long now_us = (now % (int64_t)ONE_SECOND_NS) / ONE_MICROSECOND_NS;
+        double delta = (double)event->delta_ns / ONE_MICROSECOND_NS;
+        fprintf(stderr, "%li.%06li: Scheduling %s in %.3f us\n",
+            now_seconds, now_us, event->name, delta);
+    }
+
+    if (event->next != NULL) {
+        if (trace_schedule) {
+            fprintf(stderr, "%s was already scheduled.\n", event->name);
+        }
         cancel_event(event);
+    }
 
     event->scheduled_ns = scheduled;
 
-    if (!event_list) {
-        event->next = NULL;
-        event_list = event;
-        next_event = scheduled;
-        return;
-    }
+    struct event_t** next_ptr = &event_list;
 
-    struct event_t* item = event_list;
-
-    while (item && item->scheduled_ns < scheduled) {
-        item = item->next;
+    // Insert event into sorted list.
+    while (*next_ptr && (*next_ptr)->scheduled_ns < scheduled) {
+        next_ptr = &((*next_ptr)->next);
     }
-    event->next = item->next;
-    item->next = event;
+    event->next = *next_ptr;
+    *next_ptr = event;
+
+    update_next_event();
 }
 
-void run_scheduler(uint64_t current_time)
+void run_scheduler(uint64_t current_time, unsigned trace)
 {
+    trace_schedule = trace;
     if (next_event > current_time)
         return;
 
@@ -46,12 +64,19 @@ void run_scheduler(uint64_t current_time)
         struct event_t* event = event_list;
         event_list = event_list->next;
         event->next = NULL;
+        update_next_event();
 
-        // Update next_event
-        next_event = (event_list == NULL) ? UINT64_MAX : event_list->scheduled_ns;
+        int64_t late_ns = current_time - event->scheduled_ns;
+
+        if (trace) {
+            long seconds = current_time / ONE_SECOND_NS;
+            long us = (current_time % (int64_t)ONE_SECOND_NS) / ONE_MICROSECOND_NS;
+            fprintf(stderr, "%li.%06li: Event %s dispatched. It was %.3f us late.\n",
+                seconds, us, event->name, (double)late_ns / ONE_MICROSECOND_NS);
+        }
 
         // Run callback
-        event->callback(event, current_time - event->scheduled_ns);
+        event->callback(event, late_ns);
     }
 }
 
@@ -60,11 +85,21 @@ void cancel_event(struct event_t *event)
 {
     struct event_t** next_ptr = &event_list;
 
+    if (trace_schedule) {
+        int64_t now = get_current_time();
+        long seconds = now / ONE_SECOND_NS;
+        long us = (now % (int64_t)ONE_SECOND_NS) / ONE_MICROSECOND_NS;
+        fprintf(stderr, "%li.%06li: Event %s canceled\n",
+                seconds, us, event->name);
+    }
+
+    // find and remove event from list
     while(*next_ptr != NULL) {
         struct event_t* next = *next_ptr;
         if (next == event) {
             *next_ptr = next->next;
             event->next = NULL;
+            update_next_event();
             return;
         }
         next_ptr = &next->next;

--- a/scheduler.h
+++ b/scheduler.h
@@ -1,0 +1,29 @@
+
+#pragma once
+
+#include <stdint.h>
+
+#define ONE_SECOND_NS 1000000000.0
+#define ONE_MILISECOND_NS 1000000.0
+
+
+struct event_t;
+
+// event callbacks get called with their event and how many ns have passed
+// since their scheduled event time.
+// If event was dynamically allocated, the callback should free it.
+typedef void (*callback_t)(struct event_t *event, int64_t late_ns);
+
+struct event_t {
+    int64_t delta_ns;
+    callback_t callback;
+
+    // internal state
+    struct event_t *next;
+    int64_t scheduled_ns;
+};
+
+void schedule_event(struct event_t *event);
+void cancel_event(struct event_t *event);
+void run_scheduler(uint64_t current_time);
+uint64_t get_current_time();

--- a/scheduler.h
+++ b/scheduler.h
@@ -28,4 +28,5 @@ struct event_t {
 void schedule_event(struct event_t *event);
 void cancel_event(struct event_t *event);
 void run_scheduler(uint64_t current_time, unsigned trace);
+int64_t scheduler_next();
 int64_t get_current_time();

--- a/scheduler.h
+++ b/scheduler.h
@@ -5,6 +5,7 @@
 
 #define ONE_SECOND_NS 1000000000.0
 #define ONE_MILISECOND_NS 1000000.0
+#define ONE_MICROSECOND_NS 1000.0
 
 
 struct event_t;
@@ -17,6 +18,7 @@ typedef void (*callback_t)(struct event_t *event, int64_t late_ns);
 struct event_t {
     int64_t delta_ns;
     callback_t callback;
+    const char* name;
 
     // internal state
     struct event_t *next;
@@ -25,5 +27,5 @@ struct event_t {
 
 void schedule_event(struct event_t *event);
 void cancel_event(struct event_t *event);
-void run_scheduler(uint64_t current_time);
-uint64_t get_current_time();
+void run_scheduler(uint64_t current_time, unsigned trace);
+int64_t get_current_time();


### PR DESCRIPTION
*This is a major refactor that's taking longer than I'd like.*
*So I'm creating a draft pull request in case anyone has comments, or wants contribute.*

This PR contains a few things:

 * Throttling (to stop the emulator pegging the cpu at 100%)
 * Scheduling, so devices don't need to be polled after every instruction. 
 * A refactor of the DSK emulation. 
 * Modelling DSK as a state-machine
 * Separate emulation of the hawk drive, with somewhat-realistic head movement timings.
 * DMA refactor


### Current Status: 

Can now boot WIPL and LOAD again.
Might even be getting slightly further, because I added interrupts.
Other things which use DMA might break?
