### PR TITLE
Fix cpu6 detect

### DIFF
--- a/cpu6.c
+++ b/cpu6.c
@@ -2398,6 +2398,14 @@ static int semaphore_op(void) {
 	exit(1);
 }
 
+/* 76 - Enable parity checking
+ * 86 - Disable parity checking
+ */
+static int parity_op(void) {
+	// unimplemented
+	return 0;
+}
+
 /*
  *	The CPU has directly controlled flags for C N Z I
  *	We know from the branch rules there is an internal V flag
@@ -2487,6 +2495,8 @@ unsigned cpu6_execute_one(unsigned trace)
 		return alu5x_op();
 	if (op == 0x67)
 		return block_op(0x67, trace);
+	if (op == 0x76 || op == 0x86)
+		return parity_op();
 	if (op < 0x70)
 		return x_op();
 	if (op == 0x77 || op == 0x78)

--- a/cpu6.c
+++ b/cpu6.c
@@ -1058,12 +1058,9 @@ static int dec(unsigned reg, unsigned val)
 static int clr(unsigned reg, unsigned v)
 {
 	reg_write(reg, v);
-	alu_out &= ~(ALU_F | ALU_L | ALU_M);
-	if (v == 0)
-		alu_out |= ALU_V;
-	else
-		/* Gets us past the tests but is probably wrong */
-		alu_out ^= ALU_V;
+	// Explicitly clears L and F flags
+	alu_out &= ~(ALU_L | ALU_F);
+	logic_flags(v);
 	return 0;
 }
 
@@ -1253,12 +1250,11 @@ static uint16_t dec16(uint16_t a, uint16_t imm)
 	return r;
 }
 
-/* Assume behaviour matches CLR */
 static uint16_t clr16(uint16_t a, uint16_t imm)
 {
-	alu_out &= ~(ALU_F | ALU_L | ALU_M);
-/*	if (imm == 0) */
-		alu_out |= ALU_V;
+	// Explicitly clears L and F flags
+	alu_out &= ~(ALU_L | ALU_F);
+	logic_flags16(imm);
 	return imm;
 }
 


### PR DESCRIPTION
CLR needs to set V flag depending on value for various cpu6 detection code to work.

Also stub parity enable/disable.

Allows `?DSKT` to correctly detect and report that it's running on cpu6

Before:

```
./centurion ../SOFTERM/\?/\?DSKT.4.bin
Centurion Binary ../SOFTERM/?/?DSKT.4.bin loaded; entry at 0164
[07]?DSKT 7.0

** CPU 5 **
RETURN TO LOADER(L); ERROR LOG ON CRT(C), PRINTER(P), OR BOTH(B)? 
```

After

```
./centurion ../SOFTERM/\?/\?DSKT.4.bin
Centurion Binary ../SOFTERM/?/?DSKT.4.bin loaded; entry at 0164
[07]?DSKT 7.0

** CPU 6 **
RETURN TO LOADER(L); ERROR LOG ON CRT(C), PRINTER(P), OR BOTH(B)? 
```
